### PR TITLE
Fix data leakage + split temporal + decisiones de diseño documentadas

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,14 +289,16 @@ Lee el CSV, aplica todas las transformaciones y genera el parquet del offline st
 **Transformaciones en orden:**
 1. Construye la columna `fecha` a partir de `anio` y `mes`
 2. Selecciona las columnas relevantes y dropea nulos
-3. Filtra por `date_from` y `date_to` si se especificaron (usando `.pipe()` para mantener el method chaining)
-4. Encodea `tipoextraccion` con `LabelEncoder` (texto → número)
-5. Calcula los features de ventana con pandas vectorizado (`groupby + rolling + shift`)
+3. Encodea `tipoextraccion` con `LabelEncoder` (texto → número)
+4. Calcula los features de ventana con pandas vectorizado (`groupby + rolling + shift`) sobre el **dataset completo**
+5. **Aplica el filtro de fechas** (`date_from` / `date_to`) recién aquí, después de los features
 6. Genera la fila futura por pozo para el online store
 7. Guarda el parquet en `/opt/airflow/feature_store/data/well_features.parquet`
 8. Ejecuta `feast apply` para registrar el parquet en el registry de Feast
 
-**Decisión de diseño:** Se usa pandas vectorizado (`groupby + rolling`) en lugar de un loop por pozo. Esto es más eficiente porque pandas procesa todas las filas en paralelo internamente, evitando la sobrecarga de iterar fila por fila en Python.
+**Decisión de diseño — orden del filtro de fechas:** El filtro se aplica *después* del cálculo de features para evitar data leakage. Si se filtrara primero, el rolling de la primera fila del rango solo tendría contexto desde `date_from`, perdiendo todo el historial anterior. Por ejemplo, si se entrena con datos desde 2021, el `avg_prod_gas_10m` de enero 2021 igual refleja los 10 meses previos (2020), no solo los datos del rango de entrenamiento.
+
+**Decisión de diseño — pandas vectorizado:** Se usa `groupby + rolling` en lugar de un loop por pozo. Pandas procesa todas las filas internamente sin iterar en Python puro, lo que es significativamente más eficiente con datasets de cientos de miles de filas.
 
 ### Task 3: `populate_online_store`
 
@@ -306,9 +308,11 @@ Lee el parquet, se queda con la última fila de cada pozo (la fila futura sin ta
 
 ### Task 4: `split_data`
 
-Obtiene los features históricos del offline store via Feast usando `get_historical_features`, que hace un **point-in-time lookup**: para cada fila del `entity_df`, busca los features tal como eran en esa fecha, evitando data leakage.
+Obtiene los features históricos del offline store via Feast usando `get_historical_features`, que hace un **point-in-time lookup**: para cada par `(idpozo, fecha)`, devuelve los features tal como eran en esa fecha exacta, garantizando que no hay data leakage entre el pasado y el futuro.
 
-Después dropea las filas futuras (`prod_gas = None`), define `X` e `y` para cada target, y splitea en train/test con `random_state=42` para reproducibilidad.
+Después descarta las filas futuras (`prod_gas = None`) y divide en train/test con un **split temporal**.
+
+**Decisión de diseño — split temporal en lugar de split aleatorio:** Para series de tiempo, un split aleatorio introduce data leakage: el modelo podría entrenarse con datos de 2023 para predecir datos de 2020. El split temporal garantiza que el modelo solo ve datos pasados durante el entrenamiento. Se usa el 80% de fechas más antiguas como train y el 20% más reciente como test.
 
 **Por qué el split se hace acá y no en `train_model`:** Todos los experimentos se evalúan sobre el mismo conjunto de test. Si el split se hiciera dentro de cada `train_model`, cada experimento podría tener un test set distinto y las métricas no serían comparables.
 
@@ -428,7 +432,35 @@ El modelo con mejor `r2` por target queda taggeado con el alias `production` en 
 
 Desde la UI de Airflow en http://localhost:8080, triggerear el DAG `ml_pipeline_oil_and_gas` con los parámetros:
 
-- `date_from`: fecha de inicio del dataset (opcional, formato `YYYY-MM-DD`)
-- `date_to`: fecha de fin del dataset (opcional, formato `YYYY-MM-DD`)
+- `date_from`: fecha de inicio del rango de entrenamiento (formato `YYYY-MM-DD`)
+- `date_to`: fecha de fin del rango de entrenamiento (formato `YYYY-MM-DD`)
 
-Si no se especifican fechas, se usa el dataset completo.
+**Rango recomendado para entornos locales:** `date_from=2023-01-01`, `date_to=2023-12-31`.
+
+**Decisión de diseño — elección del rango de fechas:** Se recomienda este rango por dos razones:
+
+1. **Restricción de memoria en entornos locales:** `get_historical_features` de Feast carga el parquet completo en memoria para resolver el point-in-time join. Con 9 contenedores corriendo, el worker de Airflow dispone de ~1.5-2GB libres, insuficientes para datasets de más de un año. En producción, con un backend distribuido para Feast (BigQuery, Spark), se utilizaría el rango 2021-2023 sin esta limitación. La restricción es del backend local (parquet + SQLite), no de la arquitectura.
+
+2. **Representatividad industrial del rango 2021-2023 en producción:** El año 2020 fue atípico por la caída de demanda energética durante COVID-19. A partir de 2021 la producción no convencional en Vaca Muerta retomó su tendencia de crecimiento sostenido. Además, las técnicas de completación y fractura cambiaron radicalmente entre 2012 y 2021 (de 1.500 a 2.500 lb de proppant por pie, costos de USD 20M a USD 11M por pozo), por lo que datos de pozos antiguos representan una realidad operativa distinta a la actual e introducen ruido en el modelo. Los features de ventana (`avg_prod_gas_10m`, `last_prod_gas`) igualmente incorporan el historial completo previo a `date_from` gracias al orden de operaciones en `prepare_offline_store`.
+
+**Sustento de la decisión — fuentes:**
+
+*Sobre el impacto de COVID-19 en 2020:*
+- Ben Salah, A. (2025). The Impact of COVID‐19 on Oil and Natural Gas Production. *OPEC Energy Review*. Wiley. https://onlinelibrary.wiley.com/doi/10.1111/opec.12321 — Confirma impacto negativo en producción de petróleo y gas en 14 países productores entre enero 2020 y diciembre 2021.
+- U.S. Energy Information Administration. (2024). *Argentina's crude oil and natural gas production near record highs*. https://www.eia.gov/todayinenergy/detail.php?id=63924 — Reporta que la producción de Vaca Muerta retomó crecimiento sostenido recién a partir de 2021.
+
+*Sobre la madurez de Vaca Muerta a partir de 2021:*
+- Rystad Energy. (2023). *Argentina's Vaca Muerta shale patch could produce 1 million bpd in 2030*. https://www.rystadenergy.com/news/argentina-s-vaca-muerta-shale-patch — Señala que el desarrollo regional se aceleró en 2021 post-COVID y que las proyecciones toman como referencia el desempeño de pozos completados en 2021-2022.
+- OilPrice.com. (2023). *Vaca Muerta's Sweet Crude Attracts Global Energy Giants*. https://oilprice.com/Energy/Crude-Oil/Vaca-Muertas-Sweet-Crude-Attracts-Global-Energy-Giants.html — Para junio 2023, Vaca Muerta producía 296.577 bbl/día de shale oil, un 24% más que el mismo período de 2022.
+
+*Sobre la evolución de técnicas de completación (pozos 2012-2013 no son comparables a 2021+):*
+- Rystad Energy. (2023). Op. cit. — Documenta la adopción de la filosofía "bigger-is-better": de 1.500 a 2.500 lb de proppant por pie y reducción del espaciado entre etapas de 250 a 210 pies entre 2018 y 2022.
+- AAPG Wiki. *Vaca Muerta play*. https://wiki.aapg.org/Vaca_Muerta_play — Costos de completación cayeron de USD 20-25M por pozo (2012) a USD 11-12M (2020) por cambios tecnológicos; los datos de pozos tempranos reflejan una realidad operativa distinta.
+- Pan American Energy. (2021). Applying State-of-the-Art Completion Techniques in Vaca Muerta Formation. *SPE/AAPG/SEG URTC*. https://onepetro.org/URTECONF/proceedings-abstract/21URTC/1-21URTC/D011S007R002/465470
+- Mawad, D. et al. (2023). From Exploration to Development: The Completion Evolution in Vaca Muerta. SPE-212574-MS. https://www.academia.edu/115677720
+
+*Contraargumento considerado — los modelos de decline curve se benefician de historiales largos:*
+- Lei, Z. et al. (2024). Production decline curve analysis of shale oil wells: A case study of Bakken, Eagle Ford and Permian. *ScienceDirect*. https://www.sciencedirect.com/science/article/pii/S1995822624002139 — Pozos con más de 2 años de historial permiten mayor precisión en la estimación del EUR con modelos tipo SEPD + Arps.
+- MDPI Energies. (2024). An Improved Decline Curve Analysis Method via Ensemble Learning for Shale Gas Reservoirs. https://www.mdpi.com/1996-1073/17/23/5910 — El modelo SEPD requiere datos históricos sustanciales para estimar parámetros de decline de forma confiable.
+
+> **Nota:** Este contraargumento es válido para modelos de decline curve clásicos. En este trabajo se usa un modelo de ML supervisado (RandomForest), donde la heterogeneidad tecnológica entre pozos de distintas épocas introduce ruido que puede perjudicar la generalización. Se priorizó la homogeneidad del período de entrenamiento sobre la extensión del historial.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,76 @@ El sistema tarda aproximadamente 2-3 minutos en estar completamente operativo (A
 
 ---
 
+## Cómo reproducir el entrenamiento
+
+Desde la UI de Airflow en http://localhost:8080, triggerear el DAG `ml_pipeline_oil_and_gas` con los parámetros:
+
+- `date_from`: fecha de inicio del rango de entrenamiento (formato `YYYY-MM-DD`)
+- `date_to`: fecha de fin del rango de entrenamiento (formato `YYYY-MM-DD`)
+
+**Rango recomendado para entornos locales:** `date_from=2023-01-01`, `date_to=2023-12-31`.
+
+Ver sección [Decisiones de Diseño](#decisiones-de-diseño) para la justificación completa del rango de fechas.
+
+---
+
+## Decisiones de Diseño
+
+### 1. Rango de fechas de entrenamiento: local vs. producción
+
+| Contexto | Rango | Motivo |
+|---|---|---|
+| **Entorno local** | `2023-01-01` / `2023-12-31` | `get_historical_features` de Feast carga el parquet completo en memoria para el point-in-time join. Con 9 contenedores corriendo, el worker dispone de ~1.5-2GB libres — insuficientes para más de un año de datos |
+| **Producción** | `2021-01-01` / `2023-12-31` | Con un backend distribuido (BigQuery, Spark), Feast puede manejar el dataset completo sin OOM |
+
+**Por qué 2021 como inicio en producción y no antes:** 2020 fue atípico por COVID-19 (caída de producción documentada en 14 países). A partir de 2021 Vaca Muerta retomó crecimiento sostenido. Además, las técnicas de completación cambiaron radicalmente entre 2012 y 2021 (de 1.500 a 2.500 lb de proppant por pie; costos de USD 20M a USD 11M por pozo), por lo que datos de pozos anteriores representan una realidad operativa distinta e introducen ruido.
+
+Los features de ventana (`avg_prod_gas_10m`, `last_prod_gas`) igualmente incorporan el historial completo previo a `date_from` gracias al orden de operaciones en `prepare_offline_store`.
+
+**Fuentes:**
+
+*Sobre el impacto de COVID-19 en 2020:*
+- Ben Salah, A. (2025). The Impact of COVID‐19 on Oil and Natural Gas Production. *OPEC Energy Review*. Wiley. https://onlinelibrary.wiley.com/doi/10.1111/opec.12321 — Confirma impacto negativo en producción de petróleo y gas en 14 países productores entre enero 2020 y diciembre 2021.
+- U.S. Energy Information Administration. (2024). *Argentina's crude oil and natural gas production near record highs*. https://www.eia.gov/todayinenergy/detail.php?id=63924 — Reporta que la producción de Vaca Muerta retomó crecimiento sostenido recién a partir de 2021.
+
+*Sobre la madurez de Vaca Muerta a partir de 2021:*
+- Rystad Energy. (2023). *Argentina's Vaca Muerta shale patch could produce 1 million bpd in 2030*. https://www.rystadenergy.com/news/argentina-s-vaca-muerta-shale-patch — Señala que el desarrollo regional se aceleró en 2021 post-COVID y que las proyecciones toman como referencia el desempeño de pozos completados en 2021-2022.
+- OilPrice.com. (2023). *Vaca Muerta's Sweet Crude Attracts Global Energy Giants*. https://oilprice.com/Energy/Crude-Oil/Vaca-Muertas-Sweet-Crude-Attracts-Global-Energy-Giants.html — Para junio 2023, Vaca Muerta producía 296.577 bbl/día de shale oil, un 24% más que el mismo período de 2022.
+
+*Sobre la evolución de técnicas de completación (pozos 2012-2013 no son comparables a 2021+):*
+- Rystad Energy. (2023). Op. cit. — Documenta la adopción de la filosofía "bigger-is-better": de 1.500 a 2.500 lb de proppant por pie y reducción del espaciado entre etapas de 250 a 210 pies entre 2018 y 2022.
+- AAPG Wiki. *Vaca Muerta play*. https://wiki.aapg.org/Vaca_Muerta_play — Costos de completación cayeron de USD 20-25M por pozo (2012) a USD 11-12M (2020) por cambios tecnológicos; los datos de pozos tempranos reflejan una realidad operativa distinta.
+- Pan American Energy. (2021). Applying State-of-the-Art Completion Techniques in Vaca Muerta Formation. *SPE/AAPG/SEG URTC*. https://onepetro.org/URTECONF/proceedings-abstract/21URTC/1-21URTC/D011S007R002/465470
+- Mawad, D. et al. (2023). From Exploration to Development: The Completion Evolution in Vaca Muerta. SPE-212574-MS. https://www.academia.edu/115677720
+
+*Contraargumento considerado — los modelos de decline curve se benefician de historiales largos:*
+- Lei, Z. et al. (2024). Production decline curve analysis of shale oil wells: A case study of Bakken, Eagle Ford and Permian. *ScienceDirect*. https://www.sciencedirect.com/science/article/pii/S1995822624002139 — Pozos con más de 2 años de historial permiten mayor precisión en la estimación del EUR con modelos tipo SEPD + Arps.
+- MDPI Energies. (2024). An Improved Decline Curve Analysis Method via Ensemble Learning for Shale Gas Reservoirs. https://www.mdpi.com/1996-1073/17/23/5910 — El modelo SEPD requiere datos históricos sustanciales para estimar parámetros de decline de forma confiable.
+
+> **Nota:** Este contraargumento es válido para modelos de decline curve clásicos. En este trabajo se usa un modelo de ML supervisado (RandomForest), donde la heterogeneidad tecnológica entre pozos de distintas épocas introduce ruido que puede perjudicar la generalización. Se priorizó la homogeneidad del período de entrenamiento sobre la extensión del historial.
+
+### 2. Orden del filtro de fechas en `prepare_offline_store`
+
+El filtro se aplica **después** de calcular los features de ventana, no antes. Si se filtrara primero, el `avg_prod_gas_10m` de la primera fila del rango solo tendría contexto desde `date_from`, perdiendo todo el historial anterior. El orden correcto garantiza que el rolling usa el dataset completo antes de recortar.
+
+### 3. Split temporal en lugar de split aleatorio
+
+Para series de tiempo, un split aleatorio introduce data leakage: el modelo podría entrenarse con datos de 2023 para predecir datos anteriores. El split temporal garantiza que el modelo solo ve el pasado durante el entrenamiento (80% fechas más antiguas = train, 20% más recientes = test).
+
+### 4. `get_historical_features` de Feast para el entrenamiento
+
+El entrenamiento consume del feature store vía `get_historical_features`, que hace un point-in-time lookup: para cada par `(idpozo, fecha)` devuelve los features tal como eran en esa fecha, evitando data leakage entre períodos. El online store (SQLite) se usa para inferencia.
+
+### 5. Dos modelos independientes: `prod_gas` y `prod_pet`
+
+En pozos no convencionales, la producción de gas y petróleo no siempre están correlacionadas — un pozo puede ser predominantemente gasífero o petrolífero según la formación geológica. Mezclar features de un fluido para predecir el otro introduciría ruido. Cada modelo tiene sus propios features de ventana, sus experimentos y su alias `production` en MLFlow.
+
+### 6. Alias `production` en lugar de stages en MLFlow
+
+`transition_model_version_stage` está deprecado en versiones recientes de MLFlow. El alias `"production"` es el mecanismo recomendado y permite cargar el modelo con `mlflow.sklearn.load_model("models:/oil_gas_prod_gas@production")`.
+
+---
+
 ## Nota sobre MLFlow y seguridad de red
 
 MLFlow 3.5+ incluye un middleware de seguridad que por defecto solo acepta conexiones desde localhost. Para permitir conexiones entre contenedores Docker es necesario deshabilitar este middleware con la variable de entorno `MLFLOW_SERVER_DISABLE_SECURITY_MIDDLEWARE=true` y arrancar el servidor con `--host 0.0.0.0`. Esto está configurado en el `docker-compose.yaml`.
@@ -426,41 +496,3 @@ Cada run tiene un nombre descriptivo que incluye el target, los estimadores, la 
 
 El modelo con mejor `r2` por target queda taggeado con el alias `production` en el Model Registry.
 
----
-
-## Cómo reproducir el entrenamiento
-
-Desde la UI de Airflow en http://localhost:8080, triggerear el DAG `ml_pipeline_oil_and_gas` con los parámetros:
-
-- `date_from`: fecha de inicio del rango de entrenamiento (formato `YYYY-MM-DD`)
-- `date_to`: fecha de fin del rango de entrenamiento (formato `YYYY-MM-DD`)
-
-**Rango recomendado para entornos locales:** `date_from=2023-01-01`, `date_to=2023-12-31`.
-
-**Decisión de diseño — elección del rango de fechas:** Se recomienda este rango por dos razones:
-
-1. **Restricción de memoria en entornos locales:** `get_historical_features` de Feast carga el parquet completo en memoria para resolver el point-in-time join. Con 9 contenedores corriendo, el worker de Airflow dispone de ~1.5-2GB libres, insuficientes para datasets de más de un año. En producción, con un backend distribuido para Feast (BigQuery, Spark), se utilizaría el rango 2021-2023 sin esta limitación. La restricción es del backend local (parquet + SQLite), no de la arquitectura.
-
-2. **Representatividad industrial del rango 2021-2023 en producción:** El año 2020 fue atípico por la caída de demanda energética durante COVID-19. A partir de 2021 la producción no convencional en Vaca Muerta retomó su tendencia de crecimiento sostenido. Además, las técnicas de completación y fractura cambiaron radicalmente entre 2012 y 2021 (de 1.500 a 2.500 lb de proppant por pie, costos de USD 20M a USD 11M por pozo), por lo que datos de pozos antiguos representan una realidad operativa distinta a la actual e introducen ruido en el modelo. Los features de ventana (`avg_prod_gas_10m`, `last_prod_gas`) igualmente incorporan el historial completo previo a `date_from` gracias al orden de operaciones en `prepare_offline_store`.
-
-**Sustento de la decisión — fuentes:**
-
-*Sobre el impacto de COVID-19 en 2020:*
-- Ben Salah, A. (2025). The Impact of COVID‐19 on Oil and Natural Gas Production. *OPEC Energy Review*. Wiley. https://onlinelibrary.wiley.com/doi/10.1111/opec.12321 — Confirma impacto negativo en producción de petróleo y gas en 14 países productores entre enero 2020 y diciembre 2021.
-- U.S. Energy Information Administration. (2024). *Argentina's crude oil and natural gas production near record highs*. https://www.eia.gov/todayinenergy/detail.php?id=63924 — Reporta que la producción de Vaca Muerta retomó crecimiento sostenido recién a partir de 2021.
-
-*Sobre la madurez de Vaca Muerta a partir de 2021:*
-- Rystad Energy. (2023). *Argentina's Vaca Muerta shale patch could produce 1 million bpd in 2030*. https://www.rystadenergy.com/news/argentina-s-vaca-muerta-shale-patch — Señala que el desarrollo regional se aceleró en 2021 post-COVID y que las proyecciones toman como referencia el desempeño de pozos completados en 2021-2022.
-- OilPrice.com. (2023). *Vaca Muerta's Sweet Crude Attracts Global Energy Giants*. https://oilprice.com/Energy/Crude-Oil/Vaca-Muertas-Sweet-Crude-Attracts-Global-Energy-Giants.html — Para junio 2023, Vaca Muerta producía 296.577 bbl/día de shale oil, un 24% más que el mismo período de 2022.
-
-*Sobre la evolución de técnicas de completación (pozos 2012-2013 no son comparables a 2021+):*
-- Rystad Energy. (2023). Op. cit. — Documenta la adopción de la filosofía "bigger-is-better": de 1.500 a 2.500 lb de proppant por pie y reducción del espaciado entre etapas de 250 a 210 pies entre 2018 y 2022.
-- AAPG Wiki. *Vaca Muerta play*. https://wiki.aapg.org/Vaca_Muerta_play — Costos de completación cayeron de USD 20-25M por pozo (2012) a USD 11-12M (2020) por cambios tecnológicos; los datos de pozos tempranos reflejan una realidad operativa distinta.
-- Pan American Energy. (2021). Applying State-of-the-Art Completion Techniques in Vaca Muerta Formation. *SPE/AAPG/SEG URTC*. https://onepetro.org/URTECONF/proceedings-abstract/21URTC/1-21URTC/D011S007R002/465470
-- Mawad, D. et al. (2023). From Exploration to Development: The Completion Evolution in Vaca Muerta. SPE-212574-MS. https://www.academia.edu/115677720
-
-*Contraargumento considerado — los modelos de decline curve se benefician de historiales largos:*
-- Lei, Z. et al. (2024). Production decline curve analysis of shale oil wells: A case study of Bakken, Eagle Ford and Permian. *ScienceDirect*. https://www.sciencedirect.com/science/article/pii/S1995822624002139 — Pozos con más de 2 años de historial permiten mayor precisión en la estimación del EUR con modelos tipo SEPD + Arps.
-- MDPI Energies. (2024). An Improved Decline Curve Analysis Method via Ensemble Learning for Shale Gas Reservoirs. https://www.mdpi.com/1996-1073/17/23/5910 — El modelo SEPD requiere datos históricos sustanciales para estimar parámetros de decline de forma confiable.
-
-> **Nota:** Este contraargumento es válido para modelos de decline curve clásicos. En este trabajo se usa un modelo de ML supervisado (RandomForest), donde la heterogeneidad tecnológica entre pozos de distintas épocas introduce ruido que puede perjudicar la generalización. Se priorizó la homogeneidad del período de entrenamiento sobre la extensión del historial.

--- a/dags/dag_oil_and_gas.py
+++ b/dags/dag_oil_and_gas.py
@@ -17,7 +17,7 @@ REDUCED_FEATURES_GAS = ['tipoextraccion', 'tef', 'profundidad']
 EXPERIMENTS = [
     # prod_pet: variando n_estimators
     {'target': 'prod_pet', 'model_params': {'n_estimators': 50, 'random_state': 42}, 'features': ALL_FEATURES_PET},
-    {'target': 'prod_pet', 'model_params': {'n_estimators': 200, 'random_state': 42}, 'features': ALL_FEATURES_PET},
+    {'target': 'prod_pet', 'model_params': {'n_estimators': 100, 'random_state': 42}, 'features': ALL_FEATURES_PET},
     # prod_pet: limitando profundidad del árbol
     {'target': 'prod_pet', 'model_params': {'n_estimators': 100, 'random_state': 42, 'max_depth': 5}, 'features': ALL_FEATURES_PET},
     {'target': 'prod_pet', 'model_params': {'n_estimators': 100, 'random_state': 42, 'max_depth': 10}, 'features': ALL_FEATURES_PET},
@@ -25,7 +25,7 @@ EXPERIMENTS = [
     {'target': 'prod_pet', 'model_params': {'n_estimators': 100, 'random_state': 42}, 'features': REDUCED_FEATURES_PET},
     # prod_gas: variando n_estimators
     {'target': 'prod_gas', 'model_params': {'n_estimators': 50, 'random_state': 42}, 'features': ALL_FEATURES_GAS},
-    {'target': 'prod_gas', 'model_params': {'n_estimators': 200, 'random_state': 42}, 'features': ALL_FEATURES_GAS},
+    {'target': 'prod_gas', 'model_params': {'n_estimators': 100, 'random_state': 42}, 'features': ALL_FEATURES_GAS},
     # prod_gas: limitando profundidad
     {'target': 'prod_gas', 'model_params': {'n_estimators': 100, 'random_state': 42, 'max_depth': 5}, 'features': ALL_FEATURES_GAS},
     {'target': 'prod_gas', 'model_params': {'n_estimators': 100, 'random_state': 42, 'max_depth': 10}, 'features': ALL_FEATURES_GAS},
@@ -93,10 +93,9 @@ def ml_pipeline():
     columns = ['idpozo', 'fecha', 'prod_pet', 'prod_gas', 'tipoextraccion', 'profundidad', 'tef', 'prod_agua']
 
     # En tercer lugar filtramos las columnas, dropeamos nulos y ordenamos ascendentemente para calcular las nuevas variables explicativas
+    # El filtro de fechas se aplica DESPUÉS del cálculo de features para preservar el contexto histórico del rolling
     df = (df[columns]
           .dropna()
-          .pipe(lambda df: df[df['fecha'] >= date_from] if date_from else df) # Filtra desde date_from si se especificó
-          .pipe(lambda df: df[df['fecha'] <= date_to] if date_to else df) # Filtra hasta date_to si se especificó
           .sort_values(['idpozo', 'fecha'])
           .reset_index(drop = True)
           )
@@ -118,6 +117,13 @@ def ml_pipeline():
         # Cuántas lecturas lleva el pozo hasta este momento
         n_readings = lambda x: x.groupby('idpozo').cumcount() + 1
     )
+
+    # Aplicamos el filtro de fechas DESPUÉS de calcular los features
+    # Así el rolling de la primera fila del rango usa toda la historia disponible, no solo desde date_from
+    if date_from:
+        df = df[df['fecha'] >= date_from].reset_index(drop = True)
+    if date_to:
+        df = df[df['fecha'] <= date_to].reset_index(drop = True)
 
     # Generamos la fila futura por pozo para el online store (sin target)
     future = (df.groupby('idpozo').tail(1).copy()
@@ -168,14 +174,17 @@ def ml_pipeline():
   @task
   def split_data(feature_store_repo):
     """
-    Obtiene los features históricos del offline store via Feast, dropea las filas futuras
-    y divide el dataset en conjuntos de entrenamiento y test para cada target.
+    Obtiene los features históricos del offline store via Feast usando get_historical_features,
+    que hace un point-in-time lookup: para cada par (idpozo, fecha), devuelve los features
+    tal como eran en esa fecha, garantizando que no haya data leakage.
+
+    Después descarta las filas futuras (sin target) y divide en train/test con un split
+    temporal (train = pasado, test = futuro).
 
     Args: feature_store_repo (str) - path al repositorio de Feast.
     Retorna: dict con los paths a los archivos parquet de cada subconjunto (X_train, X_test, y_train, y_test).
     """
     from feast import FeatureStore
-    from sklearn.model_selection import train_test_split
 
     # Leemos el parquet para obtener las llaves de entidades
     offline_parquet_path = os.path.join(feature_store_repo, 'data/well_features.parquet')
@@ -209,41 +218,43 @@ def ml_pipeline():
     # Dropeamos las filas futuras (prod_gas = None) que agregamos para el online store
     training_df = training_df.dropna(subset = ['prod_gas', 'prod_pet'])
 
-    # Definimos targets y features
-    targets = ['prod_pet', 'prod_gas']
-    X = training_df.drop(columns = targets)
-    y_pet = training_df['prod_pet']
-    y_gas = training_df['prod_gas']
+    # Split temporal: el 80% más antiguo es train, el 20% más reciente es test
+    # Para series de tiempo esto es correcto: el modelo nunca ve datos futuros durante el entrenamiento
+    training_df = training_df.sort_values('event_timestamp').reset_index(drop = True)
+    unique_dates = sorted(training_df['event_timestamp'].unique())
+    cutoff_date = unique_dates[int(len(unique_dates) * 0.8)]
 
-    # Split en subconjuntos de entrenamiento y test para cada target
-    X_train_pet, X_test_pet, y_pet_train, y_pet_test = train_test_split(X, y_pet, test_size = 0.2, random_state = 42)
-    X_train_gas, X_test_gas, y_gas_train, y_gas_test = train_test_split(X, y_gas, test_size = 0.2, random_state = 42)
+    train_df = training_df[training_df['event_timestamp'] <  cutoff_date]
+    test_df  = training_df[training_df['event_timestamp'] >= cutoff_date]
+
+    # X es igual para ambos targets: mismas filas, mismas columnas (sin ID, timestamp ni targets)
+    non_features = ['idpozo', 'event_timestamp', 'prod_pet', 'prod_gas']
+    X_train = train_df.drop(columns = non_features)
+    X_test  = test_df.drop(columns = non_features)
 
     # Creamos la carpeta si no existe y guardamos los splits en disco
     os.makedirs('/opt/airflow/data/splits', exist_ok = True)
 
-    X_train_pet.to_parquet('/opt/airflow/data/splits/X_train_pet.parquet')
-    X_test_pet.to_parquet('/opt/airflow/data/splits/X_test_pet.parquet')
-    X_train_gas.to_parquet('/opt/airflow/data/splits/X_train_gas.parquet')
-    X_test_gas.to_parquet('/opt/airflow/data/splits/X_test_gas.parquet')
+    X_train.to_parquet('/opt/airflow/data/splits/X_train.parquet')
+    X_test.to_parquet('/opt/airflow/data/splits/X_test.parquet')
 
-    y_pet_train.to_frame().to_parquet('/opt/airflow/data/splits/y_pet_train.parquet')
-    y_pet_test.to_frame().to_parquet('/opt/airflow/data/splits/y_pet_test.parquet')
-    y_gas_train.to_frame().to_parquet('/opt/airflow/data/splits/y_gas_train.parquet')
-    y_gas_test.to_frame().to_parquet('/opt/airflow/data/splits/y_gas_test.parquet')
+    train_df[['prod_pet']].to_parquet('/opt/airflow/data/splits/y_pet_train.parquet')
+    test_df[['prod_pet']].to_parquet('/opt/airflow/data/splits/y_pet_test.parquet')
+    train_df[['prod_gas']].to_parquet('/opt/airflow/data/splits/y_gas_train.parquet')
+    test_df[['prod_gas']].to_parquet('/opt/airflow/data/splits/y_gas_test.parquet')
 
     return {
         'prod_pet': {
-            'X_train': '/opt/airflow/data/splits/X_train_pet.parquet',
-            'X_test': '/opt/airflow/data/splits/X_test_pet.parquet',
+            'X_train': '/opt/airflow/data/splits/X_train.parquet',
+            'X_test':  '/opt/airflow/data/splits/X_test.parquet',
             'y_train': '/opt/airflow/data/splits/y_pet_train.parquet',
-            'y_test': '/opt/airflow/data/splits/y_pet_test.parquet',
+            'y_test':  '/opt/airflow/data/splits/y_pet_test.parquet',
         },
         'prod_gas': {
-            'X_train': '/opt/airflow/data/splits/X_train_gas.parquet',
-            'X_test': '/opt/airflow/data/splits/X_test_gas.parquet',
+            'X_train': '/opt/airflow/data/splits/X_train.parquet',
+            'X_test':  '/opt/airflow/data/splits/X_test.parquet',
             'y_train': '/opt/airflow/data/splits/y_gas_train.parquet',
-            'y_test': '/opt/airflow/data/splits/y_gas_test.parquet',
+            'y_test':  '/opt/airflow/data/splits/y_gas_test.parquet',
         }
     }
   @task
@@ -268,7 +279,7 @@ def ml_pipeline():
 
       # Leemos los subconjuntos de train filtrando solo las features del experimento
       X_train = pd.read_parquet(splits.get(target).get('X_train'))[features]
-      y_train = pd.read_parquet(splits.get(target).get('y_train'))
+      y_train = pd.read_parquet(splits.get(target).get('y_train')).squeeze()
 
       # Creamos el modelo con los hiperparámetros del experimento
       # Random Forest construye N árboles de decisión, cada uno entrenado con una muestra aleatoria distinta de los datos y un subconjunto aleatorio de features
@@ -316,7 +327,7 @@ def ml_pipeline():
 
     # Leemos los subconjuntos de train y test
     X_test = pd.read_parquet(splits.get(results['target']).get('X_test'))[features]
-    y_test = pd.read_parquet(splits.get(results['target']).get('y_test'))
+    y_test = pd.read_parquet(splits.get(results['target']).get('y_test')).squeeze()
 
     # Cargamos el modelo
     loaded_model = pickle.load(open(results['model_path'], 'rb'))
@@ -336,8 +347,8 @@ def ml_pipeline():
     mlflow.set_experiment('ml_pipeline_oil_and_gas')
 
     with mlflow.start_run(run_name = run_name): # Abrimos un nuevo run con ese nombre
-        mlflow.sklearn.autolog() # Logueamos automáticamente parámetros del modelo (hiperparámetros, etc.)
         mlflow.log_param('target', results['target']) # Logueamos manualmente el target para filtrar en la UI
+        mlflow.log_params(results['model_params']) # Logueamos los hiperparámetros del experimento
         mlflow.log_metric('mae', mae) # Métricas de evaluación
         mlflow.log_metric('mse', mse)
         mlflow.log_metric('rmse', rmse)


### PR DESCRIPTION
Hola Fede, te dejo este PR con los fixes que encontré revisando el pipeline en detalle.

## Problemas detectados en la versión anterior

**1. Data leakage en `prepare_offline_store`**

El filtro de fechas (`date_from` / `date_to`) se aplicaba *antes* de calcular los features de ventana. Esto hacía que el `avg_prod_gas_10m` de la primera fila del rango de entrenamiento solo tuviera contexto desde `date_from`, sin historial previo. Por ejemplo, si entrenás con datos desde 2021, el rolling de enero 2021 debería usar los 10 meses anteriores de 2020 — pero con el bug, los calculaba solo sobre los datos del rango.

Fix: el filtro ahora se aplica *después* del rolling, así la ventana siempre usa el dataset completo.

**2. Split aleatorio en lugar de split temporal**

El split original no respetaba el orden temporal. Para series de tiempo, un split aleatorio introduce data leakage: el modelo puede entrenarse con datos de 2023 para predecir datos de 2020. El split temporal garantiza que el modelo solo ve el pasado durante el entrenamiento (80% fechas más antiguas = train, 20% más recientes = test).

**3. Fixes menores de runtime**

- `.squeeze()` en la lectura de los targets (se guardaban como DataFrame y causaban `DataConversionWarning` en sklearn)
- Saqué `mlflow.sklearn.autolog()` y puse logging explícito: el autolog estaba serializando el modelo dos veces, lo que multiplicaba el uso de memoria y causaba OOM en el worker
- Bajé `n_estimators` de 200 a 100 por el mismo motivo de memoria

## README

Agregué una sección de Decisiones de Diseño con justificación para cada decisión, una tabla local vs producción para el rango de fechas, y bibliografía con fuentes industriales (EIA, Rystad Energy, OPEC, SPE).

---

Testeé con `date_from=2023-01-01`, `date_to=2023-12-31` y el DAG corrió completamente verde (26 tasks exitosas). Las screenshots están en `screenshots/`.