### PR TITLE
fix: API /forecast respeta rango de fechas + schedule mensual en el DAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Para cada pozo, se genera una fila extra con fecha del próximo mes y sin target
 
 ## DAG: `ml_pipeline_oil_and_gas`
 
-El DAG orquesta todo el pipeline. Se puede triggerear desde la UI de Airflow con parámetros opcionales `date_from` y `date_to` para filtrar el dataset por rango de fechas, lo que permite reproducir el entrenamiento para cualquier fecha histórica con un solo comando.
+El DAG orquesta todo el pipeline. Corre automáticamente el **primer día de cada mes** (`schedule="0 0 1 * *"`), alineado con la frecuencia natural del dataset (producción mensual por pozo). También se puede triggerear manualmente desde la UI de Airflow con parámetros opcionales `date_from` y `date_to` para filtrar el dataset por rango de fechas, lo que permite reproducir el entrenamiento para cualquier fecha histórica con un solo comando.
 
 ### Flujo de tasks
 
@@ -453,25 +453,25 @@ Devuelve el pronóstico de producción de un pozo para el próximo mes.
 | `target` | string | NO | `"gas"` (default) o `"pet"` |
 
 **Funcionamiento:**
-1. Consulta el online store de Feast para obtener los features más recientes del pozo
-2. Selecciona el modelo en producción según el target: `oil_gas_prod_gas@production` o `oil_gas_prod_pet@production`
-3. Predice y devuelve el resultado
+1. Genera el rango mensual entre `date_start` y `date_end` (primer día de cada mes)
+2. Para cada fecha del rango, elige la fuente de features:
+   - **Fecha dentro del parquet (histórica):** usa los features reales del offline store. `avg_prod_10m` fue calculado con `shift(1)` en `prepare_offline_store`, por lo que no contiene información de la fecha consultada ni de fechas posteriores (sin leakage)
+   - **Fecha futura (posterior al último dato del parquet):** usa los features del online store (estado más reciente del pozo). El modelo predice un solo paso; se repite la misma predicción para todos los meses futuros sin actualización autoregresiva, para evitar distribution shift en `avg_prod_10m`
+3. Devuelve un punto por cada mes del rango
 
 **Ejemplo de respuesta:**
 ```json
 {
   "id_well": "3640",
-  "target": "gas",
   "data": [
-    {
-      "date": "2017-02-01",
-      "prod": 498.94
-    }
+    { "date": "2023-10-01", "prod": 312.45 },
+    { "date": "2023-11-01", "prod": 298.10 },
+    { "date": "2023-12-01", "prod": 298.10 }
   ]
 }
 ```
 
-**Decisión de diseño:** Para la entrega parcial se devuelve solo el próximo mes disponible independientemente del rango solicitado. Esto está documentado en el swagger.
+**Decisión de diseño — predicción autoregresiva descartada:** Actualizar `avg_prod_10m` con valores predichos introduce distribution shift (el feature fue calculado sobre producción real en entrenamiento). En pozos shale con decline pronunciado, el error se autocorrela. La alternativa de repetir la misma predicción para fechas futuras es más honesta respecto a las limitaciones del modelo single-step.
 
 ### `GET /api/v1/wells`
 

--- a/api/main.py
+++ b/api/main.py
@@ -45,9 +45,18 @@ def get_wells(date_query: str):
 @app.get("/api/v1/forecast")
 def get_forecast(id_well: str, date_start: str, date_end: str, target: str = "gas"):
     """
-    Devuelve el pronóstico de producción de un pozo dado.
-    Para la entrega parcial se devuelve el próximo mes disponible
-    independientemente del rango solicitado.
+    Devuelve el pronóstico de producción de un pozo para cada mes entre date_start y date_end.
+
+    Estrategia de inferencia según el tipo de fecha:
+    - Fechas dentro del parquet (históricas): se usan los features reales del offline store.
+      avg_prod_10m fue calculado con shift(1) en prepare_offline_store, así que el valor
+      en la fila de fecha T contiene producción de T-10 a T-1 (sin leakage).
+    - Fechas futuras (posteriores al último dato del parquet): se usan los features del online
+      store (estado más reciente del pozo). El modelo predice un solo paso; se repite la misma
+      predicción para todos los meses futuros del rango. No se hace actualización autoregresiva
+      porque alimentar el modelo con sus propias predicciones cambia la distribución de
+      avg_prod_10m respecto al entrenamiento (distribution shift).
+
     Args:
         id_well (str) - identificador del pozo.
         date_start (str) - fecha de inicio en formato YYYY-MM-DD.
@@ -58,62 +67,74 @@ def get_forecast(id_well: str, date_start: str, date_end: str, target: str = "ga
         if target not in ("gas", "pet"):
             raise HTTPException(status_code = 400, detail = "target debe ser 'gas' o 'pet'")
 
-        # Obtenemos los features más recientes del pozo desde el online store
-        store = FeatureStore(repo_path = FEATURE_STORE_REPO)
-        online_features = store.get_online_features(
-            features=[
-                'well_stats:tipoextraccion',
-                'well_stats:avg_prod_gas_10m',
-                'well_stats:avg_prod_pet_10m',
-                'well_stats:last_prod_gas',
-                'well_stats:last_prod_pet',
-                'well_stats:n_readings',
-                'well_stats:profundidad',
-                'well_stats:tef',
-                'well_stats:prod_agua',
-            ],
-            entity_rows = [{"idpozo": int(id_well)}]
-        ).to_df()
-
-        # Verificamos que el pozo existe en el online store
-        if online_features.isnull().all(axis = 1).any():
-            raise HTTPException(status_code = 404, detail = f"No se encontraron features para el pozo {id_well}")
-
-        # Seleccionamos features y modelo según el target
-        # Cada target usa sus propios features de ventana para evitar introducir ruido entre variables que no siempre están correlacionadas
+        # Columnas de features y modelo según el target
+        # Cada target usa sus propios features de ventana para evitar ruido entre variables
+        # que no siempre están correlacionadas (un pozo puede ser gasífero o petrolífero)
         if target == "gas":
-            X = online_features[[
-                'tipoextraccion', 'tef', 'profundidad', 'prod_agua',
-                'avg_prod_gas_10m', 'last_prod_gas', 'n_readings'
-            ]]
-            model = mlflow.sklearn.load_model("models:/oil_gas_prod_gas@production") # alias "production"
-            # Este alias fue asignado por select_best_model al modelo con mejor r2 entre los 5 experimentos entrenados para gas
+            feature_cols = ['tipoextraccion', 'tef', 'profundidad', 'prod_agua',
+                            'avg_prod_gas_10m', 'last_prod_gas', 'n_readings']
+            model = mlflow.sklearn.load_model("models:/oil_gas_prod_gas@production")
         else:
-            X = online_features[[
-                'tipoextraccion', 'tef', 'profundidad', 'prod_agua',
-                'avg_prod_pet_10m', 'last_prod_pet', 'n_readings'
-            ]]
-            model = mlflow.sklearn.load_model("models:/oil_gas_prod_pet@production") # alias "production"
-            # Este alias fue asignado por select_best_model al modelo con mejor r2 entre los 5 experimentos entrenados para gas
+            feature_cols = ['tipoextraccion', 'tef', 'profundidad', 'prod_agua',
+                            'avg_prod_pet_10m', 'last_prod_pet', 'n_readings']
+            model = mlflow.sklearn.load_model("models:/oil_gas_prod_pet@production")
 
-        # Predecimos
-        prediction = float(model.predict(X)[0])
+        # Rango mensual (primer día de cada mes)
+        dates = pd.date_range(start = date_start, end = date_end, freq = 'MS')
+        if len(dates) == 0:
+            raise HTTPException(status_code = 400, detail = "date_start debe ser anterior a date_end")
 
-        # Calculamos la fecha del próximo mes disponible
+        # Cargamos el offline store indexado por fecha para el pozo dado
         df = pd.read_parquet(PARQUET_PATH)
         df['fecha'] = pd.to_datetime(df['fecha'])
-        last_date = df[df['idpozo'] == int(id_well)]['fecha'].max()
-        next_date = last_date + pd.DateOffset(months = 1)
+        well_df = df[df['idpozo'] == int(id_well)].set_index('fecha')
+
+        if well_df.empty:
+            raise HTTPException(status_code = 404, detail = f"No se encontraron datos para el pozo {id_well}")
+
+        # Features del online store: se cargan solo si el rango incluye fechas futuras
+        online_X = None
+
+        results = []
+        for date in dates:
+            if date in well_df.index:
+                # Fecha histórica: features reales del offline store.
+                # avg_prod_10m en la fila T = media de prod de T-10 a T-1 (shift(1) aplicado
+                # en prepare_offline_store). No hay leakage.
+                X = well_df.loc[[date], feature_cols]
+            else:
+                # Fecha futura: features del online store (estado más reciente del pozo).
+                # Se reutiliza online_X para todos los meses futuros del rango.
+                if online_X is None:
+                    store = FeatureStore(repo_path = FEATURE_STORE_REPO)
+                    online_features = store.get_online_features(
+                        features=[
+                            'well_stats:tipoextraccion',
+                            'well_stats:avg_prod_gas_10m',
+                            'well_stats:avg_prod_pet_10m',
+                            'well_stats:last_prod_gas',
+                            'well_stats:last_prod_pet',
+                            'well_stats:n_readings',
+                            'well_stats:profundidad',
+                            'well_stats:tef',
+                            'well_stats:prod_agua',
+                        ],
+                        entity_rows = [{"idpozo": int(id_well)}]
+                    ).to_df()
+
+                    if online_features.isnull().all(axis = 1).any():
+                        raise HTTPException(status_code = 404, detail = f"No se encontraron features para el pozo {id_well}")
+
+                    online_X = online_features[feature_cols]
+
+                X = online_X
+
+            pred = max(0.0, float(model.predict(X)[0]))  # floor en 0: producción no puede ser negativa
+            results.append({"date": date.strftime("%Y-%m-%d"), "prod": round(pred, 2)})
 
         return {
             "id_well": id_well,
-            "target": target,
-            "data": [
-                {
-                    "date": next_date.strftime("%Y-%m-%d"),
-                    "prod": prediction
-                }
-            ]
+            "data": results
         }
 
     except HTTPException:

--- a/dags/dag_oil_and_gas.py
+++ b/dags/dag_oil_and_gas.py
@@ -38,9 +38,15 @@ EXPERIMENTS = [
 @dag(
     dag_id = 'ml_pipeline_oil_and_gas',
     description = 'Pipeline de Machine Learning con Airflow, MLFlow y Feature Store - Trabajo Práctico Final',
+    schedule = '0 0 1 * *', # Corre el primer día de cada mes a medianoche. El dataset es mensual
+                             # (producción por pozo por mes), por lo que el reentrenamiento mensual
+                             # es la frecuencia natural. En producción con un backend distribuido
+                             # para Feast (BigQuery, Spark), correría sobre el rango completo.
+                             # En entornos locales se recomienda triggear manualmente con date_from
+                             # y date_to para acotar el dataset y evitar OOM.
     params = { # Los params permiten configurar el DAG desde la UI de Airflow sin tocar el código
-        'date_from': Param(default = None, type = ['null', 'string'], description = 'Fecha inicio (YYYY-MM-DD)'),
-        'date_to': Param(default = None, type = ['null', 'string'], description = 'Fecha fin (YYYY-MM-DD)'),
+        'date_from': Param(default = None, type = ['null', 'string'], description = 'Fecha inicio (YYYY-MM-DD). Si es None, usa todos los datos disponibles.'),
+        'date_to': Param(default = None, type = ['null', 'string'], description = 'Fecha fin (YYYY-MM-DD). Si es None, usa todos los datos disponibles.'),
     }
 )
 def ml_pipeline():


### PR DESCRIPTION
Dos cambios para cerrar los últimos gaps de la entrega parcial y dejar un requerimiento de la final resuelto.

## 1. Fix: `/api/v1/forecast` ahora respeta `date_start` y `date_end`

**El problema:** La spec OpenAPI de la consigna define que el endpoint tiene que devolver un array con la producción esperada para **cada fecha entre `date_start` y `date_end`**. La implementación anterior ignoraba completamente esos parámetros y siempre devolvía un solo punto: el "próximo mes" calculado desde el último registro del pozo en el parquet. Si pedías un rango de 6 meses, te devolvía exactamente lo mismo que si pedías 2 años.

**El fix:** Ahora genera el rango mensual completo (`pd.date_range(freq='MS')`) y para cada fecha elige la fuente de features correcta:

- **Fecha dentro del parquet (histórica):** usa los features reales del offline store para esa fecha exacta. `avg_prod_10m` fue calculado con `shift(1)` en `prepare_offline_store`, así que el valor en la fila de fecha T contiene producción de T-10 a T-1, nunca de T en adelante. No hay leakage.

- **Fecha futura (posterior al último dato del parquet):** usa los features del online store (estado más reciente del pozo). El modelo predice un solo paso; se repite la misma predicción para todos los meses futuros sin actualización autoregresiva. La razón para no actualizar: `avg_prod_10m` fue calculado sobre producción real en entrenamiento — si lo recalculáramos sobre predicciones, estaríamos cambiando la distribución del feature (distribution shift), y en pozos shale con decline pronunciado el error se autocorrela hacia arriba.

**Otros cambios menores:**
- Se elimina el campo `target` de la respuesta (no estaba en la spec)
- Se agrega `max(0.0, pred)` como floor: producción no puede ser negativa

**Antes:**
```json
{ "id_well": "3640", "target": "gas", "data": [{ "date": "2024-02-01", "prod": 312.45 }] }
```
_(siempre un solo punto, ignorando el rango pedido)_

**Después**, para `date_start=2023-10-01&date_end=2023-12-01`:
```json
{
  "id_well": "3640",
  "data": [
    { "date": "2023-10-01", "prod": 312.45 },
    { "date": "2023-11-01", "prod": 298.10 },
    { "date": "2023-12-01", "prod": 305.22 }
  ]
}
```

---

## 2. Schedule mensual en el DAG

Se agrega `schedule="0 0 1 * *"` al decorator `@dag`. El dataset es de producción mensual por pozo, así que el reentrenamiento el primer día de cada mes es la frecuencia natural. Este es uno de los requerimientos de la entrega final (28/5).

En entornos locales sigue siendo recomendable triggear manualmente con `date_from`/`date_to` para acotar el dataset y evitar OOM con el backend local de Feast. El schedule está pensado para cuando se corra con un backend distribuido (BigQuery, Spark).

---

Todo documentado en el README en las secciones correspondientes.