### PR TITLE
fix: online store consistency — borrar registry y SQLite antes de feast apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,12 @@ Lee el parquet, se queda con la última fila de cada pozo (la fila futura sin ta
 
 **Decisión de diseño:** Corre después de `prepare_offline_store` para garantizar que el parquet ya existe. El online store siempre tiene exactamente una fila por pozo.
 
+**Decisión de diseño — borrado del registry y el SQLite antes de `feast apply`:** Al inicio de `prepare_offline_store` se borran `registry/registry.db` y `online_store/online.db` antes de correr `feast apply`. Esto garantiza que el online store siempre quede sincronizado con el parquet de la corrida actual.
+
+Sin este borrado, pueden ocurrir dos problemas encadenados:
+1. **Datos rancios en el online store:** Feast no sobreescribe entradas cuyo timestamp almacenado sea más reciente que el nuevo dato. Si una corrida anterior usó un rango de fechas más amplio (timestamps más nuevos), los valores viejos persisten aunque el parquet haya cambiado.
+2. **"no such table" en `populate_online_store`:** `feast apply` solo crea las tablas del SQLite si detecta cambios en el registry. Si el registry dice que la infraestructura ya existe, no recrea las tablas aunque el SQLite haya sido borrado — y `write_to_online_store` falla. Borrando también el registry, `feast apply` trata todo como instalación nueva y recrea las tablas correctamente.
+
 ### Task 4: `split_data`
 
 Obtiene los features históricos del offline store via Feast usando `get_historical_features`, que hace un **point-in-time lookup**: para cada par `(idpozo, fecha)`, devuelve los features tal como eran en esa fecha exacta, garantizando que no hay data leakage entre el pasado y el futuro.
@@ -459,19 +465,31 @@ Devuelve el pronóstico de producción de un pozo para el próximo mes.
    - **Fecha futura (posterior al último dato del parquet):** usa los features del online store (estado más reciente del pozo). El modelo predice un solo paso; se repite la misma predicción para todos los meses futuros sin actualización autoregresiva, para evitar distribution shift en `avg_prod_10m`
 3. Devuelve un punto por cada mes del rango
 
-**Ejemplo de respuesta:**
+**Ejemplo: rango histórico (pozo 3640, enero–junio 2023)**
+
+Los primeros dos meses tienen registros reales en el parquet; a partir de marzo el pozo ya no tiene datos y la API usa el online store repitiendo la misma predicción:
+
 ```json
 {
   "id_well": "3640",
   "data": [
-    { "date": "2023-10-01", "prod": 312.45 },
-    { "date": "2023-11-01", "prod": 298.10 },
-    { "date": "2023-12-01", "prod": 298.10 }
+    { "date": "2023-01-01", "prod": 27.8  },
+    { "date": "2023-02-01", "prod": 25.02 },
+    { "date": "2023-03-01", "prod": 27.8  },
+    { "date": "2023-04-01", "prod": 27.8  },
+    { "date": "2023-05-01", "prod": 27.8  },
+    { "date": "2023-06-01", "prod": 27.8  }
   ]
 }
 ```
 
+Enero y febrero varían porque cada mes usa sus propios features históricos (producción real de los meses anteriores). A partir de marzo, el pozo no tiene más registros en el dataset: la API toma el estado más reciente del online store y repite la misma predicción para todos los meses futuros del rango.
+
+**Cómo identificar el límite en la respuesta:** el primer valor que se repite consecutivamente con el mismo número indica la transición del offline store al online store para ese pozo.
+
 **Decisión de diseño — predicción autoregresiva descartada:** Actualizar `avg_prod_10m` con valores predichos introduce distribution shift (el feature fue calculado sobre producción real en entrenamiento). En pozos shale con decline pronunciado, el error se autocorrela. La alternativa de repetir la misma predicción para fechas futuras es más honesta respecto a las limitaciones del modelo single-step.
+
+**Nota sobre consistencia del online store:** En versiones anteriores del código se observaba una diferencia llamativa entre la predicción del último mes histórico y la del primer mes futuro (online store), causada por datos rancios en el SQLite de corridas anteriores. Este comportamiento fue corregido: `prepare_offline_store` borra el registry y el SQLite antes de cada `feast apply`, garantizando que el online store siempre refleje el estado actual del parquet.
 
 ### `GET /api/v1/wells`
 

--- a/dags/dag_oil_and_gas.py
+++ b/dags/dag_oil_and_gas.py
@@ -150,6 +150,19 @@ def ml_pipeline():
     # Guardamos el DataFrame en formato parquet
     offline_feat_df.to_parquet(offline_parquet_path, index = False)
 
+    # Borramos el registry y el SQLite antes de feast apply para garantizar consistencia
+    # con el parquet actual. Feast no sobreescribe entradas del online store cuyo timestamp
+    # sea más reciente que el nuevo dato. Además, feast apply solo crea las tablas del
+    # online store si detecta cambios en el registry — si el registry existe y dice que
+    # la infraestructura ya está creada, no recrea las tablas aunque el SQLite no exista.
+    # Borrando ambos forzamos una instalación limpia en cada corrida del DAG.
+    for path in [
+        os.path.join(feature_store_repo, 'online_store/online.db'),
+        os.path.join(feature_store_repo, 'registry/registry.db'),
+    ]:
+        if os.path.exists(path):
+            os.remove(path)
+
     # Registramos las definiciones de features.py en el registry de Feast y apuntamos al parquet recién generado
     subprocess.run(['feast', 'apply'], cwd = feature_store_repo, check = True)
 
@@ -158,6 +171,10 @@ def ml_pipeline():
     """
     Lee el parquet del offline store, toma la última fila de cada pozo
     (la fila futura sin target) y la materializa en el online store (SQLite).
+
+    feast apply recrea las tablas del SQLite antes de escribir, garantizando
+    consistencia con el parquet actual (el borrado del SQLite ocurre en
+    prepare_offline_store antes del feast apply de esa task).
     """
     # Importamos librería
     from feast import FeatureStore


### PR DESCRIPTION
## Problema

Al correr el DAG con distintos rangos de fechas entre ejecuciones, el online store (SQLite) podía quedar con datos de corridas anteriores que no reflejaban el parquet actual. Esto causaba predicciones incorrectas en la API para fechas futuras.

Dos bugs encadenados:

**Bug 1 — datos rancios:** Feast no sobreescribe entradas del online store si el timestamp almacenado es más reciente que el nuevo dato. Si una corrida anterior usó el dataset completo y la siguiente usó `date_from=2023-01-01`, los features viejos (con timestamps más nuevos) persistían en el SQLite.

**Bug 2 — "no such table":** Al intentar borrar solo el SQLite para forzar la actualización, `feast apply` no recreaba las tablas porque el registry decía que la infraestructura ya existía. `write_to_online_store` fallaba con `OperationalError: no such table: oil_gas_production_well_stats`.

## Fix

En `prepare_offline_store`, antes de `feast apply`, borrar ambos archivos:
- `online_store/online.db` — el SQLite con los datos
- `registry/registry.db` — el estado de infraestructura de Feast

Sin registry, `feast apply` trata todo como instalación nueva, recrea las tablas del SQLite, y `populate_online_store` puede escribir correctamente. El online store queda siempre sincronizado con el parquet de esa corrida.

## Validación

- DAG completo corriendo exitosamente (26 tasks en verde)
- Predicciones del online store consistentes con el estado actual del parquet
- Verificado inspeccionando el parquet directamente con `pd.read_parquet` desde el contenedor

## Documentación

Se actualiza el README con:
- Explicación de la decisión de diseño del borrado en `prepare_offline_store`
- Ejemplo real de respuesta del endpoint `/api/v1/forecast` con valores observados (pozo 3640)
- Nota sobre el comportamiento del límite histórico/futuro en la respuesta