### PR TITLE
Fix/readme and pipeline improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Dado el historial de producción de un pozo, predecir cuántos m³ de gas o petr
 
 El RFC especifica dos datasets del [Ministerio de Energía de Argentina](http://datos.energia.gob.ar):
 
-- **Dataset 1 — Producción por pozo** ✅ en uso: lecturas mensuales de producción de gas, petróleo y agua por pozo no convencional.
-- **Dataset 2 — Listado de pozos** ❌ pendiente de integración: metadata estática por pozo (empresa operadora, formación geológica, cuenca, coordenadas). Ver [issue #18](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/18).
+- **Dataset 1 — Producción por pozo** en uso: lecturas mensuales de producción de gas, petróleo y agua por pozo no convencional.
+- **Dataset 2 — Listado de pozos** pendiente de integración: metadata extra por pozo (empresa operadora, formación geológica, cuenca, coordenadas) que no está disponible en el Dataset 1. Su integración mejoraría la capacidad predictiva del modelo, pero queda fuera del scope de este trabajo: el foco está en la arquitectura MLOps que mantiene el modelo productivo, no en optimizar el modelo en sí.
 
-El dataset 2 es especialmente relevante para resolver la limitación documentada del modelo: al usar features estáticos del pozo (formación, cuenca) en inferencia futura, el modelo podría diferenciar pozos mejor que con el estado actual donde converge a la media. Las variables principales del dataset 1 son:
+Las variables principales del Dataset 1 son:
 
 | Variable | Tipo | Rol |
 |---|---|---|
@@ -35,9 +35,9 @@ Se recomienda filtrar el dataset a partir de 2021 pasando `date_from=` al trigge
 
 ### Modelo y métricas
 
-Se entrenan dos modelos independientes (`prod_gas` y `prod_pet`) usando **RandomForestRegressor**. Se evalúan 10 experimentos por target variando `n_estimators`, `max_depth` y el conjunto de features. El modelo con mejor score es promovido automáticamente a producción en MLFlow.
+Se entrenan dos modelos independientes (`prod_gas` y `prod_pet`) usando **RandomForestRegressor**. Se evalúan 10 experimentos en total (5 por target) variando `n_estimators`, `max_depth` y el conjunto de features. El modelo con mejor R² es promovido automáticamente a producción en MLFlow.
 
-Las métricas de evaluación son **R²** (coeficiente de determinación), **RMSE** y **MAE** sobre un test set temporal (20% de fechas más recientes).
+Las métricas de evaluación son **R²**, **RMSE** y **MAE** sobre un test set temporal (20% de fechas más recientes).
 
 ---
 
@@ -45,10 +45,6 @@ Las métricas de evaluación son **R²** (coeficiente de determinación), **RMSE
 
 - [Arquitectura](#arquitectura)
 - [Posicionamiento MLOps](#posicionamiento-mlops)
-  - [Arquitectura FTI](#arquitectura-fti)
-  - [Nivel de madurez](#nivel-de-madurez)
-  - [Deuda técnica identificada](#deuda-técnica-identificada)
-  - [Reproducibilidad](#reproducibilidad)
 - [Screenshots](#screenshots)
 - [Setup](#setup)
 - [Cómo reproducir el entrenamiento](#cómo-reproducir-el-entrenamiento)
@@ -56,8 +52,8 @@ Las métricas de evaluación son **R²** (coeficiente de determinación), **RMSE
 - [Feature Store](#feature-store)
 - [Features del Modelo](#features-del-modelo)
 - [DAG: `ml_pipeline_oil_and_gas`](#dag-ml_pipeline_oil_and_gas)
+- [Relación entre el entrenamiento y la API](#relación-entre-el-entrenamiento-y-la-api)
 - [API REST](#api-rest)
-- [MLFlow](#mlflow)
 
 ---
 
@@ -67,25 +63,25 @@ Las métricas de evaluación son **R²** (coeficiente de determinación), **RMSE
 Dataset (CSV)
     ↓
 Airflow DAG
-    ├── download_dataset → descarga el CSV
-    ├── prepare_offline_store → calcula features y genera el parquet + feast apply
-    ├── populate_online_store → materializa features recientes al SQLite
-    ├── split_data → obtiene features del feature store y splitea
-    ├── train_model (x N) → entrena experimentos en serie
-    ├── evaluate_model (x N) → evalúa y loguea en MLFlow
-    └── select_best_model → promueve el mejor modelo a producción
+    ├── download_dataset        → descarga el CSV
+    ├── prepare_offline_store   → calcula features y genera el parquet + feast apply
+    ├── populate_online_store   → materializa features recientes al SQLite
+    ├── split_data              → obtiene features del feature store y splitea
+    ├── train_model (x N)       → entrena experimentos en serie
+    ├── evaluate_model (x N)    → evalúa y loguea en MLFlow
+    └── select_best_model       → promueve el mejor modelo a producción
 
 Feature Store (Feast)
     ├── Offline Store (parquet) → features históricos para entrenamiento
-    └── Online Store (SQLite) → features más recientes para inferencia
+    └── Online Store (SQLite)   → features más recientes para inferencia
 
 MLFlow
-    ├── Experiment tracking → métricas y artefactos por experimento
-    └── Model Registry → versiones y alias de producción
+    ├── Experiment tracking     → métricas y artefactos por experimento
+    └── Model Registry          → versiones y alias de producción
 
 API REST (FastAPI)
-    ├── GET /api/v1/forecast → pronóstico de producción de un pozo (gas o petróleo)
-    └── GET /api/v1/wells → listado de pozos disponibles
+    ├── GET /api/v1/forecast    → pronóstico de producción de un pozo (gas o petróleo)
+    └── GET /api/v1/wells       → listado de pozos disponibles
 ```
 
 ---
@@ -102,7 +98,9 @@ El proyecto implementa el patrón **Feature → Training → Inference (FTI)**, 
 | **Training Pipeline** | Leer features históricos, entrenar y guardar el modelo | Tareas `split_data` + `train_model` + `evaluate_model` + `select_best_model` del DAG |
 | **Inference Pipeline** | Usar el modelo y features en tiempo real para predecir | API REST (FastAPI) + online store (SQLite) |
 
-El Feature Store es el contrato entre los tres pipelines: garantiza que training e inference lean exactamente las mismas features con la misma lógica de transformación, eliminando el **training-serving skew** (problema que ocurre cuando el modelo se entrena con features calculados de una forma pero en producción se calculan de otra, lo que genera predicciones sesgadas aunque el modelo en sí sea correcto) por inconsistencia de datos.
+En este proyecto los tres pipelines están implementados dentro de un único DAG de Airflow, lo que simplifica la orquestación pero los acopla al mismo schedule. En un sistema más maduro cada pipeline correría como un DAG independiente — por ejemplo, el Feature Pipeline podría correr diariamente mientras el Training Pipeline corre mensualmente.
+
+El Feature Store es el contrato entre los tres pipelines: garantiza que training e inference lean exactamente las mismas features con la misma lógica de transformación, eliminando el **training-serving skew** — el problema que ocurre cuando el modelo se entrena con features calculados de una forma pero en producción se calculan de otra, generando predicciones sesgadas aunque el modelo en sí sea correcto.
 
 ### Nivel de madurez
 
@@ -118,11 +116,9 @@ Este proyecto implementa **Nivel 1 de MLOps (Continuous Training)** según la cl
 | CI/CD | No | No | Integración total | **No** |
 | Monitoreo | No | Métricas básicas | Métricas de sistema y modelo | **Parcial** (métricas de entrenamiento en MLFlow) |
 
-Para alcanzar **Nivel 2** se necesitaría agregar: tests automáticos por cada commit (datos, modelo e infraestructura), canary o blue-green deployment (estrategias de despliegue que sirven el modelo nuevo solo a una fracción del tráfico antes de reemplazar el anterior por completo, reduciendo el riesgo de rollouts fallidos), y monitoreo activo en producción (prediction bias, feature distribution shift).
+Para alcanzar **Nivel 2** se necesitaría agregar: tests automáticos por cada commit, canary o blue-green deployment, y monitoreo activo en producción (prediction bias, feature distribution shift).
 
 ### Deuda técnica identificada
-
-Aplicando el checklist de Sculley et al. (2015) al proyecto:
 
 | Pregunta | Estado |
 |---|---|
@@ -130,43 +126,23 @@ Aplicando el checklist de Sculley et al. (2015) al proyecto:
 | ¿Puedo reentrenar con un solo comando? | ✅ Un trigger desde la UI de Airflow corre el pipeline completo |
 | ¿Cuántos lenguajes distintos necesito para el pipeline? | ✅ Python únicamente |
 | ¿Hay tests para los datos de entrada? | ❌ No hay validación de schema del CSV descargado |
+| ¿El LabelEncoder se versiona junto al modelo? | ❌ Se re-entrena en cada corrida pero no se persiste en MLFlow como artefacto |
+| ¿Hay monitoreo de drift en producción? | ❌ No hay detección automática de prediction bias ni feature distribution shift |
+| ¿Los datos están versionados? | ❌ El CSV se descarga sin hashear — si el gobierno actualiza datos históricos, no hay forma de detectarlo |
 
-**Deuda de modelo conocida:** RandomForest tiende a converger a la media del dataset cuando los inputs del online store están fuera de la distribución de entrenamiento. Ver [limitación documentada en la sección API REST](#get-apiv1forecast). Esta deuda es del modelo, no del pipeline: el feature store entrega los features correctos, pero el modelo carece de capacidad discriminativa suficiente para diferenciar pozos en inferencia futura con una sola fila de contexto.
+**Deuda de artefactos:** El `LabelEncoder` de `tipoextraccion` se re-entrena en cada corrida dentro de `prepare_offline_store` pero no se guarda como artefacto en MLFlow junto al modelo. Es una transformación *model-dependent* que debería persistirse. Si el CSV upstream incorpora nuevas categorías de extracción entre una corrida y la siguiente, el mapeo puede cambiar, generando training-serving skew latente.
 
-**Deuda de monitoreo:** No hay detección automática de **prediction bias** (tendencia sistemática del modelo a sobreestimar o subestimar respecto a los valores reales) ni **feature distribution shift** (cambio en la distribución estadística de los features de entrada respecto a lo visto durante el entrenamiento, que puede degradar silenciosamente la calidad de las predicciones). El pipeline detectaría degradación del modelo solo al comparar el `r2` (R² o coeficiente de determinación: mide qué proporción de la varianza del target explica el modelo; 1.0 es predicción perfecta, 0 equivale a predecir siempre la media del dataset) del próximo reentrenamiento mensual contra versiones anteriores en MLFlow.
-
-**Deuda de artefactos:** El `LabelEncoder` de `tipoextraccion` se re-entrena en cada corrida dentro de `prepare_offline_store` pero no se guarda como artefacto en MLFlow junto al modelo. Usando la taxonomía de transformaciones de la Clase 3: `prepare_offline_store` aplica transformaciones *model-independent* (filtrado, agrupación por pozo/mes, agregaciones) que son reutilizables y se almacenan en el feature store. El `LabelEncoder` es una transformación *model-dependent* (codificación categórica parametrizada por los datos de entrenamiento) que debería persistirse en MLFlow junto al modelo. Si el CSV upstream incorpora nuevas categorías de extracción entre una corrida y la siguiente, el mapeo puede cambiar, generando training-serving skew latente.
-
-**Deuda de Point-in-Time:** El pipeline construye el dataset de entrenamiento con un join convencional entre features y fechas. No se aplica corrección *point-in-time*, lo que significa que no se reconstruye el estado exacto de cada pozo justo antes del evento de entrenamiento. Si el CSV upstream actualiza retroactivamente filas históricas (el gobierno republica datos corregidos), el modelo podría haberse entrenado con información que no existía en el momento del evento, introduciendo **data leakage** implícito (filtración de información del futuro hacia el pasado durante el entrenamiento: el modelo aprende patrones que no podría haber visto en producción, lo que infla artificialmente las métricas de evaluación y genera un modelo que rinde peor de lo esperado en producción).
-
-**Deuda de sesgos:** El modelo tiene tres sesgos estructurales no mitigados:
-
-1. **Sesgo histórico en los datos:** El dataset refleja decisiones operativas pasadas, no la capacidad de producción real de cada pozo. Pozos con mayor historial de inversión o mantenimiento aparecen con features de ventana (`avg_prod_gas_10m`, `last_prod_gas`) inflados respecto a su producción basal. El modelo aprende esas condiciones operativas codificadas, no la geología del pozo. Esto es sesgo de medición: la variable medida (producción registrada) no captura de forma neutral el fenómeno objetivo (capacidad real del yacimiento).
-
-2. **Convergencia a la media como sesgo diferencial por grupo:** La limitación documentada de RandomForest (tiende a predecir cercano a la media del training set cuando los inputs están fuera de distribución) no afecta de forma uniforme a todos los pozos. En pozos de alta producción el modelo sistemáticamente subestima; en pozos de baja producción sobreestima. Esto es el equivalente en regresión al **disparate impact** (impacto diferencial del modelo sobre distintos grupos: cuando el error sistemático no es aleatorio sino que varía de forma consistente según una característica del grupo, el modelo trata desigualmente a grupos que deberían recibir predicciones igualmente precisas), donde el grupo está definido por nivel de producción en lugar de un atributo demográfico.
-
-3. **Métricas de evaluación no desagregadas:** `evaluate_model` calcula R² y RMSE globales sobre el test set completo. Las métricas agregadas pueden ocultar errores sistemáticos por subgrupo: un R² de 0.85 global es compatible con R² de 0.95 para pozos convencionales y 0.60 para pozos no convencionales. Calcular R² y RMSE por `tipoextraccion` es el análogo en regresión a las métricas de equidad grupales (equal error rates across groups): permite detectar si el modelo comete errores diferenciados según el tipo de extracción, y es especialmente relevante porque `tipoextraccion` es una de las features del modelo.
-
-4. **No fairness through unawareness:** Remover `tipoextraccion` de los features no eliminaría el sesgo diferencial por tipo de extracción. `avg_prod_gas_10m` y `last_prod_gas` son proxies directos de ella: distintos tipos de extracción tienen perfiles de producción histórica muy distintos, por lo que esas variables de ventana ya codifican implícitamente el tipo de extracción. Un modelo entrenado sin `tipoextraccion` aprendería igualmente el patrón a través de los proxies.
-
-**Por qué las técnicas estándar de debiasing no aplican:** Las técnicas de mitigación de sesgo (reweighing, adversarial debiasing, threshold optimizer) están diseñadas para casos donde el atributo sensible *no debería* correlacionar con el target — por ejemplo, cuando la correlación es un artefacto de discriminación histórica en crédito, salud o justicia penal. En el TP, `tipoextraccion` *sí debería* correlacionar con la producción: distintos tipos de extracción producen volúmenes genuinamente distintos de gas/petróleo por razones físicas (presión de yacimiento, permeabilidad, método de recuperación). Aplicar reweighing para descorrelacionar `tipoextraccion` de las predicciones eliminaría una señal causal real y degradaría el modelo. La mitigación correcta en este contexto es la **transparencia evaluativa**: calcular métricas desagregadas por grupo y loguear feature importance, no corregir las predicciones.
+**Deuda de monitoreo:** No hay detección automática de prediction bias ni feature distribution shift. El pipeline detectaría degradación del modelo solo al comparar el R² del próximo reentrenamiento mensual contra versiones anteriores en MLFlow.
 
 ### Reproducibilidad
-
-La reproducibilidad de un modelo en producción requiere tres condiciones simultáneas: mismo código, mismos datos y mismo entorno. El proyecto cumple dos de tres:
 
 | Pilar | Estado | Detalle |
 |---|---|---|
 | **Código** | ✅ | Pipeline definido como código Python en Git, versionado en Airflow como DAG |
-| **Datos** | ❌ | CSV descargado de URL pública sin hashear ni versionar — si el gobierno actualiza el dataset retroactivamente, no hay forma de saber qué datos generaron un modelo específico en producción |
-| **Entorno** | ✅ | Docker Compose con dependencias pineadas; `uvicorn==0.40.0` pineado explícitamente para evitar conflicto conocido con Feast |
+| **Datos** | ❌ | CSV descargado de URL pública sin hashear ni versionar |
+| **Entorno** | ✅ | Docker Compose con dependencias pineadas; `uvicorn==0.40.0` y `feast==0.47.0` pineados explícitamente |
 
-El gap de datos implica que **la linaje de datos es parcial**: MLFlow registra los parámetros y métricas de cada run, pero no hay un hash o snapshot del CSV asociado a cada versión del modelo. Para cerrar esta brecha se podría hashear el CSV al inicio del DAG y loguear ese hash como parámetro en MLFlow, de modo que cada versión del modelo quede vinculada a una versión concreta del dataset.
-
-Lo que sí está bien cubierto en términos de tracking y empaquetado:
-- **Experiment tracking**: cada run de Airflow registra en MLFlow los hiperparámetros (`n_estimators`, `max_depth`, `test_size`), las métricas (`r2`, `mse`, `rmse`) y el modelo como artefacto
-- **Rollback**: el alias `production` en MLFlow Model Registry puede reasignarse a cualquier versión anterior con un solo comando, sin necesidad de reentrenar
-- **Pipeline as Code**: el DAG en Airflow define el orden de ejecución, las dependencias entre tareas y el schedule en código versionado, no en configuración manual de un servidor
+El gap de datos implica que la linaje de datos es parcial: MLFlow registra parámetros y métricas de cada run, pero no hay un hash del CSV asociado a cada versión del modelo. El punto de extensión natural para cerrar esta brecha es la tarea `download_dataset`.
 
 ---
 
@@ -196,7 +172,7 @@ El DAG fue entrenado con datos de 2023. Al pedir predicción para los 3 meses si
 
 ### API REST - Endpoint `/api/v1/forecast` — fechas históricas
 
-Al pedir predicción para 4 meses dentro del período de entrenamiento (2023), el modelo usa los features reales de cada mes desde el parquet. Cada mes tiene su propio `avg_prod_gas_10m` y `last_prod_gas` calculados con producción real, por lo que los valores predichos varían. Esto permite evaluar el comportamiento del modelo sobre el training set.
+Al pedir predicción para 4 meses dentro del período de entrenamiento (2023), el modelo usa los features reales de cada mes desde el parquet. Cada mes tiene su propio `avg_prod_gas_10m` calculado con producción real, por lo que los valores predichos varían.
 
 ![GET Forecast II](screenshots/GET_Forecast_II.png)
 
@@ -226,14 +202,12 @@ __pycache__/
 
 ### 3. Dependencias (`.env`)
 
-Crear un archivo `.env` en la raíz del proyecto con el siguiente contenido:
-
 ```
-AIRFLOW_UID = 501
-_PIP_ADDITIONAL_REQUIREMENTS = pandas scikit-learn mlflow feast fastapi uvicorn==0.40.0
+AIRFLOW_UID=501
+_PIP_ADDITIONAL_REQUIREMENTS=pandas scikit-learn mlflow feast fastapi uvicorn==0.40.0
 ```
 
-> **Nota:** `uvicorn==0.40.0` está pineado para evitar un conflicto de dependencias entre `feast` y `apache-airflow-core 3.1.7`, que requiere `uvicorn>=0.37.0`. Sin este pin, `feast` instala una versión incompatible que rompe el api-server de Airflow.
+> **Nota:** `uvicorn==0.40.0` está pineado para evitar un conflicto de dependencias entre `feast` y `apache-airflow-core 3.1.7`. `feast==0.47.0` está pineado en el contenedor de la API para que coincida con la versión del worker de Airflow — versiones distintas de Feast son incompatibles en la serialización del online store.
 
 ### 4. Volúmenes en `docker-compose.yaml`
 
@@ -256,23 +230,21 @@ Esto hace que cada carpeta local sea visible dentro del contenedor en `/opt/airf
 ```
 oil_and_gas_mlops_pipeline/
 ├── dags/
-│   └── dag_oil_and_gas.py ← DAG principal
+│   └── dag_oil_and_gas.py          ← DAG principal
 ├── feature_store/
-│   ├── data/ ← parquet con features históricos (generado, no se sube)
-│   ├── registry/ ← metadata de Feast (generado, no se sube)
-│   ├── online_store/ ← features recientes en SQLite (generado, no se sube)
-│   ├── feature_store.yaml ← configuración de Feast
-│   └── features.py ← definición de entidades y feature views
+│   ├── data/                       ← parquet con features históricos (generado, no se sube)
+│   ├── registry/                   ← metadata de Feast (generado, no se sube)
+│   ├── online_store/               ← features recientes en SQLite (generado, no se sube)
+│   ├── feature_store.yaml          ← configuración de Feast
+│   └── features.py                 ← definición de entidades y feature views
 ├── api/
-│   └── main.py ← API REST con FastAPI
-├── screenshots/ ← capturas de pantalla del sistema funcionando
-├── mlruns/ ← artefactos de MLFlow (generado, no se sube)
-├── logs/ ← logs de Airflow (generado, no se sube)
+│   └── main.py                     ← API REST con FastAPI
+├── screenshots/                    ← capturas de pantalla del sistema funcionando
+├── mlruns/                         ← artefactos de MLFlow (generado, no se sube)
+├── logs/                           ← logs de Airflow (generado, no se sube)
 ├── plugins/
 ├── config/
-│   └── airflow.cfg ← configuración de Airflow (generado por airflow-init)
-├── roadmap.md ← funcionalidades pendientes para la entrega final
-├── .env ← variables de entorno (no se sube al repo)
+├── .env                            ← variables de entorno (no se sube al repo)
 ├── .gitignore
 └── docker-compose.yaml
 ```
@@ -293,8 +265,6 @@ online_store:
 - **registry**: Feast guarda aquí la metadata (qué features existen, qué esquema tienen, dónde está el parquet)
 - **offline_store**: archivo parquet con toda la historia de features por pozo y por mes
 - **online_store**: base de datos SQLite con la última fila de cada pozo, lista para inferencia instantánea
-
-El feature store resuelve dos necesidades incompatibles con backends distintos: el offline store optimiza para alto ancho de banda y gran volumen (leer miles de filas por pozo durante entrenamiento), mientras que el online store optimiza para baja latencia en lecturas key-value (recuperar la última fila de un pozo en milisegundos durante inferencia). Un solo backend no puede optimizar ambas a la vez.
 
 ### 7. Cómo levantar el sistema
 
@@ -325,91 +295,52 @@ Desde la UI de Airflow en http://localhost:8080, triggerear el DAG `ml_pipeline_
 - `date_from`: fecha de inicio del rango de entrenamiento (formato `YYYY-MM-DD`)
 - `date_to`: fecha de fin del rango de entrenamiento (formato `YYYY-MM-DD`)
 
-El DAG puede correr con el dataset completo (sin especificar fechas), pero **se recomienda acotar el rango según la memoria disponible**. `get_historical_features` de Feast carga el parquet completo en memoria para el point-in-time join — si el worker no tiene suficiente RAM, el DAG falla con OOM (Out of Memory). Un año de datos es un punto de partida razonable para entornos con recursos limitados. El rango exacto depende de la memoria disponible en el entorno donde corra el pipeline.
-
-Ver [Decisiones de Diseño](#decisiones-de-diseño) para la justificación del rango recomendado.
-
----
-
-## Decisiones de Diseño
-
-### 1. Supuesto: los datos históricos del gobierno no se modifican retroactivamente
-
-El pipeline no hashea ni versiona el CSV descargado. El supuesto es que los datos históricos publicados por el Ministerio de Energía son inmutables una vez publicados — una fila de producción de enero 2022 no cambia en una descarga posterior.
-
-**Consecuencia:** si el gobierno corrigiera datos históricos entre dos corridas, no habría forma de detectarlo. En ese caso, dos runs con el mismo rango de fechas podrían producir modelos distintos sin advertencia.
-
-**Por qué se aceptó el supuesto:** agregar hashing del CSV introduce complejidad de infraestructura (almacenamiento de snapshots, comparación de hashes entre runs) que no está justificada mientras el supuesto se mantenga válido. Si en el futuro se detectan actualizaciones retroactivas, el punto de extensión natural es la tarea `download_dataset`.
-
-### 2. Rango de fechas de entrenamiento: local vs. producción
+El DAG puede correr con el dataset completo (sin especificar fechas), pero se recomienda acotar el rango según la memoria disponible. `get_historical_features` de Feast carga el parquet en memoria para el point-in-time join — con recursos limitados el DAG puede fallar con OOM.
 
 | Contexto | Rango | Motivo |
 |---|---|---|
-| **Entorno con recursos limitados** (ej: laptop con 9 contenedores corriendo) | `2023-01-01` / `2023-12-31` | `get_historical_features` carga el parquet completo en memoria. Con ~1.5-2GB libres disponibles, un año de datos es lo que entra sin OOM. El rango exacto varía según la RAM del entorno |
-| **Producción / entorno con más recursos** | `2021-01-01` / hasta la fecha más reciente disponible | Con más memoria o un backend distribuido (BigQuery, Spark), Feast puede manejar el dataset completo sin OOM |
+| **Entorno local** (laptop con 9 contenedores) | `2023-01-01` / `2023-12-31` | Con ~1.5-2GB libres disponibles, un año de datos es lo que entra sin OOM |
+| **Producción** | `2021-01-01` / hasta la fecha más reciente | Con más memoria o backend distribuido (BigQuery, Spark), Feast puede manejar el dataset completo |
 
-**Por qué se recomienda 2021 como inicio y no antes:** 2020 fue atípico por COVID-19 (caída de producción documentada en 14 países). A partir de 2021 Vaca Muerta retomó crecimiento sostenido. Además, las técnicas de completación cambiaron radicalmente entre 2012 y 2021 (de 1.500 a 2.500 lb de proppant por pie; costos de USD 20M a USD 11M por pozo), por lo que datos de pozos anteriores representan una realidad operativa distinta que puede introducir ruido. Dicho esto, el pipeline puede entrenarse con datos anteriores a 2021 o con el dataset completo sin ningún cambio en el código — es una recomendación de calidad de datos, no una restricción técnica.
+**Por qué 2021 como inicio:** 2020 fue atípico por COVID-19. A partir de 2021 Vaca Muerta retomó crecimiento sostenido. Además, las técnicas de completación cambiaron radicalmente entre 2012 y 2021 (de 1.500 a 2.500 lb de proppant por pie), por lo que datos anteriores representan una realidad operativa distinta que introduce ruido.
 
-Los features de ventana (`avg_prod_gas_10m`, `last_prod_gas`) igualmente incorporan el historial completo previo a `date_from` gracias al orden de operaciones en `prepare_offline_store`.
+**Importante:** el rango de fechas elegido condiciona el comportamiento posterior de la API. Ver [Relación entre el entrenamiento y la API](#relación-entre-el-entrenamiento-y-la-api).
 
-**Fuentes:**
+---
 
-*Sobre el impacto de COVID-19 en 2020:*
-- Ben Salah, A. (2025). The Impact of COVID‐19 on Oil and Natural Gas Production. *OPEC Energy Review*. Wiley. https://onlinelibrary.wiley.com/doi/10.1111/opec.12321 — Confirma impacto negativo en producción de petróleo y gas en 14 países productores entre enero 2020 y diciembre 2021.
-- U.S. Energy Information Administration. (2024). *Argentina's crude oil and natural gas production near record highs*. https://www.eia.gov/todayinenergy/detail.php?id=63924 — Reporta que la producción de Vaca Muerta retomó crecimiento sostenido recién a partir de 2021.
+## Decisiones de diseño
 
-*Sobre la madurez de Vaca Muerta a partir de 2021:*
-- Rystad Energy. (2023). *Argentina's Vaca Muerta shale patch could produce 1 million bpd in 2030*. https://www.rystadenergy.com/news/argentina-s-vaca-muerta-shale-patch — Señala que el desarrollo regional se aceleró en 2021 post-COVID y que las proyecciones toman como referencia el desempeño de pozos completados en 2021-2022.
-- OilPrice.com. (2023). *Vaca Muerta's Sweet Crude Attracts Global Energy Giants*. https://oilprice.com/Energy/Crude-Oil/Vaca-Muertas-Sweet-Crude-Attracts-Global-Energy-Giants.html — Para junio 2023, Vaca Muerta producía 296.577 bbl/día de shale oil, un 24% más que el mismo período de 2022.
+### 1. Supuesto: los datos históricos del gobierno no se modifican retroactivamente
 
-*Sobre la evolución de técnicas de completación (pozos 2012-2013 no son comparables a 2021+):*
-- Rystad Energy. (2023). Op. cit. — Documenta la adopción de la filosofía "bigger-is-better": de 1.500 a 2.500 lb de proppant por pie y reducción del espaciado entre etapas de 250 a 210 pies entre 2018 y 2022.
-- AAPG Wiki. *Vaca Muerta play*. https://wiki.aapg.org/Vaca_Muerta_play — Costos de completación cayeron de USD 20-25M por pozo (2012) a USD 11-12M (2020) por cambios tecnológicos; los datos de pozos tempranos reflejan una realidad operativa distinta.
-- Pan American Energy. (2021). Applying State-of-the-Art Completion Techniques in Vaca Muerta Formation. *SPE/AAPG/SEG URTC*. https://onepetro.org/URTECONF/proceedings-abstract/21URTC/1-21URTC/D011S007R002/465470
-- Mawad, D. et al. (2023). From Exploration to Development: The Completion Evolution in Vaca Muerta. SPE-212574-MS. https://www.academia.edu/115677720
+El pipeline no hashea ni versiona el CSV descargado. El supuesto es que los datos históricos publicados por el Ministerio de Energía son inmutables una vez publicados. Si el gobierno corrigiera datos históricos entre dos corridas, no habría forma de detectarlo. Se aceptó el supuesto porque agregar hashing introduce complejidad no justificada mientras el supuesto se mantenga válido.
 
-*Contraargumento considerado — los modelos de decline curve se benefician de historiales largos:*
-- Lei, Z. et al. (2024). Production decline curve analysis of shale oil wells: A case study of Bakken, Eagle Ford and Permian. *ScienceDirect*. https://www.sciencedirect.com/science/article/pii/S1995822624002139 — Pozos con más de 2 años de historial permiten mayor precisión en la estimación del EUR con modelos tipo SEPD + Arps.
-- MDPI Energies. (2024). An Improved Decline Curve Analysis Method via Ensemble Learning for Shale Gas Reservoirs. https://www.mdpi.com/1996-1073/17/23/5910 — El modelo SEPD requiere datos históricos sustanciales para estimar parámetros de decline de forma confiable.
+### 2. Orden del filtro de fechas en `prepare_offline_store`
 
-> **Nota:** Este contraargumento es válido para modelos de decline curve clásicos. En este trabajo se usa un modelo de ML supervisado (RandomForest), donde la heterogeneidad tecnológica entre pozos de distintas épocas introduce ruido que puede perjudicar la generalización. Se priorizó la homogeneidad del período de entrenamiento sobre la extensión del historial.
+El filtro se aplica **después** de calcular los features de ventana. Si se filtrara primero, el `avg_prod_gas_10m` de la primera fila del rango solo tendría contexto desde `date_from`, perdiendo todo el historial anterior. El orden correcto garantiza que el rolling usa el dataset completo antes de recortar.
 
-### 3. Orden del filtro de fechas en `prepare_offline_store`
-
-El filtro se aplica **después** de calcular los features de ventana, no antes. Si se filtrara primero, el `avg_prod_gas_10m` de la primera fila del rango solo tendría contexto desde `date_from`, perdiendo todo el historial anterior. El orden correcto garantiza que el rolling usa el dataset completo antes de recortar.
-
-### 4. Split temporal en lugar de split aleatorio
+### 3. Split temporal en lugar de split aleatorio
 
 Para series de tiempo, un split aleatorio introduce data leakage: el modelo podría entrenarse con datos de 2023 para predecir datos anteriores. El split temporal garantiza que el modelo solo ve el pasado durante el entrenamiento (80% fechas más antiguas = train, 20% más recientes = test).
 
-### 5. `get_historical_features` de Feast para el entrenamiento
+### 4. `get_historical_features` de Feast para el entrenamiento
 
 El entrenamiento consume del feature store vía `get_historical_features`, que hace un point-in-time lookup: para cada par `(idpozo, fecha)` devuelve los features tal como eran en esa fecha, evitando data leakage entre períodos. El online store (SQLite) se usa para inferencia.
 
-### 6. Dos modelos independientes: `prod_gas` y `prod_pet`
+### 5. Dos modelos independientes: `prod_gas` y `prod_pet`
 
 En pozos no convencionales, la producción de gas y petróleo no siempre están correlacionadas — un pozo puede ser predominantemente gasífero o petrolífero según la formación geológica. Mezclar features de un fluido para predecir el otro introduciría ruido. Cada modelo tiene sus propios features de ventana, sus experimentos y su alias `production` en MLFlow.
 
-### 7. Alias `production` en lugar de stages en MLFlow
+### 6. Alias `production` en lugar de stages en MLFlow
 
-`transition_model_version_stage` está deprecado en versiones recientes de MLFlow. El alias `"production"` es el mecanismo recomendado y permite cargar el modelo con `mlflow.sklearn.load_model("models:/oil_gas_prod_gas@production")`. Si el DAG vuelve a correr y encuentra un modelo mejor, el alias se mueve automáticamente — la API siempre sirve el mejor modelo sin cambiar el código. `select_best_model` compara solo las versiones generadas en la corrida actual — ver decisión #8.
+`transition_model_version_stage` está deprecado en versiones recientes de MLFlow. El alias `"production"` es el mecanismo recomendado. Si el DAG vuelve a correr y encuentra un modelo mejor, el alias se mueve automáticamente — la API siempre sirve el mejor modelo sin cambiar el código.
 
-### 8. `select_best_model` compara solo versiones del run actual
+### 7. `select_best_model` compara solo versiones del run actual
 
-`select_best_model` filtra por los `run_id` generados en el DAG actual, en lugar de comparar todas las versiones históricas acumuladas en MLFlow.
+`select_best_model` filtra por los `run_id` generados en el DAG actual, en lugar de comparar todas las versiones históricas acumuladas en MLFlow. Las métricas no son comparables entre runs entrenados con datasets distintos: un R² calculado sobre el test set del run A (entrenado con dataset completo) y un R² del run B (entrenado con 2023 únicamente) se evalúan sobre distribuciones distintas.
 
-**Trade-off considerado:** comparar contra el historial completo podría conservar en producción un modelo con R² más alto entrenado en una corrida anterior. Se descartó por dos razones:
+### 8. Predicción autoregresiva descartada en la API
 
-1. **Las métricas no son comparables entre runs**: un R² calculado sobre el test set del run A (entrenado con dataset completo) y un R² del run B (entrenado con 2023 únicamente) se evalúan sobre distribuciones distintas. Comparar esos valores directamente no tiene significado estadístico.
-
-2. **Rompe la reproducibilidad del pipeline**: si el modelo en `@production` depende del historial acumulado en MLFlow, dos instancias del mismo sistema (o dos colaboradores) pueden terminar con modelos distintos en producción aunque hayan corrido el mismo código con los mismos datos.
-
-**Separación de responsabilidades:** `select_best_model` elige el mejor modelo *de esta corrida*. Si ese modelo degrada respecto al ciclo anterior, el model decay report (pendiente) lo detecta y alerta. Son dos preguntas distintas que no deben mezclarse en la misma función.
-
-### 9. Predicción autoregresiva descartada en la API
-
-Para fechas futuras la API repite la misma predicción en lugar de actualizar `avg_prod_10m` con valores predichos. Alimentar el modelo con sus propias predicciones cambiaría la distribución del feature respecto al entrenamiento (distribution shift). En pozos shale con decline pronunciado, el error se autocorrelacionaría. Repetir la predicción del estado más reciente es más honesto respecto a las limitaciones de un modelo single-step.
-
+Para fechas futuras la API repite la misma predicción en lugar de actualizar `avg_prod_10m` con valores predichos. Alimentar el modelo con sus propias predicciones cambiaría la distribución del feature respecto al entrenamiento (distribution shift). En pozos shale con decline pronunciado, el error se autocorrelacionaría.
 
 ---
 
@@ -419,9 +350,8 @@ Para fechas futuras la API repite la misma predicción en lugar de actualizar `a
 
 Cuando el modelo necesita predecir la producción de un pozo, requiere features como el promedio de producción de los últimos 10 meses. Calcularlo en el momento de cada inferencia sería lento y costoso. El feature store resuelve esto separando el problema en dos partes:
 
-- **Offline Store**: almacena los features históricos de todos los pozos en todos los períodos. Se usa para entrenamiento. Internamente es un archivo **parquet** (`well_features.parquet`): un formato de tabla binario (similar a un CSV pero comprimido y de lectura mucho más rápida, especialmente al seleccionar columnas). `prepare_offline_store` toma el CSV de pozos, calcula todos los features y guarda el resultado en ese parquet. Feast lo lee para servir features al entrenamiento.
-- **Online Store**: almacena solo el estado más reciente de cada pozo. Se usa para inferencia. Es rápido porque los features ya están precomputados. Internamente es una base de datos **SQLite** (`online.db`).
-
+- **Offline Store**: almacena los features históricos de todos los pozos en todos los períodos. Se usa para entrenamiento. Internamente es un archivo parquet (`well_features.parquet`).
+- **Online Store**: almacena solo el estado más reciente de cada pozo. Se usa para inferencia. Internamente es una base de datos SQLite (`online.db`).
 
 ### Offline Store vs Online Store
 
@@ -441,7 +371,7 @@ Cuando el modelo necesita predecir la producción de un pozo, requiere features 
 
 ### ¿Por qué el online store está en SQLite y no en el parquet?
 
-El parquet puede tener millones de filas — una por pozo por mes durante años. Leerlo completo en cada request de inferencia sería inviable. El online store resuelve esto copiando solo la última fila de cada pozo al SQLite. Cuando la API necesita los features de un pozo, hace un lookup por clave primaria (`idpozo`) en O(1) — sin importar cuántos pozos o cuánta historia exista en el parquet.
+El parquet puede tener millones de filas. Leerlo completo en cada request de inferencia sería inviable. El online store resuelve esto copiando solo la última fila de cada pozo al SQLite. Cuando la API necesita los features de un pozo, hace un lookup por clave primaria (`idpozo`) en O(1).
 
 En resumen: el offline store *calcula* los features, el online store los *sirve rápido*.
 
@@ -463,8 +393,6 @@ Define el contrato de features que Feast espera encontrar en el parquet. Tiene t
 
 ### Dataset original
 
-El dataset contiene lecturas mensuales de producción por pozo. Las columnas relevantes son:
-
 - `idpozo`: identificador único del pozo
 - `anio` y `mes`: año y mes de la lectura (se combinan en `fecha`)
 - `prod_gas`: producción de gas (target)
@@ -472,7 +400,7 @@ El dataset contiene lecturas mensuales de producción por pozo. Las columnas rel
 - `prod_agua`: producción de agua (feature)
 - `tef`: tiempo efectivo de flujo (feature)
 - `profundidad`: profundidad del pozo (feature)
-- `tipoextraccion`: tipo de extracción, variable categórica encodeada con LabelEncoder (feature)
+- `tipoextraccion`: tipo de extracción, variable categórica encodada con LabelEncoder (feature)
 
 ### Features calculados
 
@@ -524,10 +452,7 @@ select_best_model
 
 ### Task 1: `download_dataset`
 
-Descarga el CSV desde la URL del gobierno y lo guarda en `/opt/airflow/data/pozos.csv` dentro del contenedor. Esta ruta no tiene volume mount, por lo que el CSV es efímero: se recrea en cada ejecución del DAG y no persiste en disco en el host.
-
-**Decisión de diseño:** Se descarga el CSV completo cada vez que corre el DAG para asegurar que los datos estén actualizados. El filtro por fechas se aplica después en `prepare_offline_store`.
-
+Descarga el CSV completo desde la URL del gobierno y lo guarda en `/opt/airflow/data/pozos.csv`. Se descarga completo cada vez para asegurar que los datos estén actualizados. El filtro por fechas se aplica después en `prepare_offline_store`.
 
 ### Task 2: `prepare_offline_store`
 
@@ -556,54 +481,26 @@ El split se hace acá y no en `train_model` para que todos los experimentos se e
 
 Entrena **dos modelos independientes**: uno para `prod_gas` y otro para `prod_pet`. El loop recorre 10 experimentos en total (5 por target), variando `n_estimators`, `max_depth` y el conjunto de features.
 
-El loop recorre **10 experimentos en total** (5 por target), todos con `RandomForestRegressor`. Cada experimento varía `n_estimators`, `max_depth` y el conjunto de features. Por cada experimento, `train_model` entrena el modelo y `evaluate_model` lo evalúa y loguea en MLFlow.
-
 | # | Target | `n_estimators` | `max_depth` | Features |
 |---|---|---|---|---|
 | 1 | `prod_pet` | 50 | sin límite | todas (7) |
 | 2 | `prod_pet` | 100 | sin límite | todas (7) |
 | 3 | `prod_pet` | 100 | 5 | todas (7) |
 | 4 | `prod_pet` | 100 | 10 | todas (7) |
-| 5 | `prod_pet` | 100 | sin límite | reducidas (3: `tipoextraccion`, `tef`, `profundidad`) |
+| 5 | `prod_pet` | 100 | sin límite | reducidas (3) |
 | 6 | `prod_gas` | 50 | sin límite | todas (7) |
 | 7 | `prod_gas` | 100 | sin límite | todas (7) |
 | 8 | `prod_gas` | 100 | 5 | todas (7) |
 | 9 | `prod_gas` | 100 | 10 | todas (7) |
-| 10 | `prod_gas` | 100 | sin límite | reducidas (3: `tipoextraccion`, `tef`, `profundidad`) |
+| 10 | `prod_gas` | 100 | sin límite | reducidas (3) |
 
-El experimento con features reducidas sirve como baseline de ablación: verifica si el modelo colapsa sin los features de ventana temporal.
+El experimento con features reducidas (`tipoextraccion`, `tef`, `profundidad`) sirve como baseline de ablación: verifica si el modelo colapsa sin los features de ventana temporal.
 
-**Features por target:**
-
-Para `prod_gas`:
-- `tipoextraccion`, `tef`, `profundidad`, `prod_agua`
-- `avg_prod_gas_10m`, `last_prod_gas`, `n_readings`
-
-Para `prod_pet`:
-- `tipoextraccion`, `tef`, `profundidad`, `prod_agua`
-- `avg_prod_pet_10m`, `last_prod_pet`, `n_readings`
-
-**Decisión de diseño sobre features separadas:** `avg_prod_gas_10m` no entra como feature para predecir `prod_pet` y viceversa. En pozos no convencionales, la producción de gas y petróleo no siempre están correlacionadas: un pozo puede ser predominantemente gasífero o petrolífero dependiendo de la formación geológica. Mezclar las features de un fluido para predecir el otro podría introducir ruido en lugar de señal.
-
-`evaluate_model` loguea en MLFlow las métricas `mae`, `mse`, `rmse` y `r2`, y registra el modelo bajo el nombre `oil_gas_prod_gas` u `oil_gas_prod_pet` según el target. Cada run agrega una nueva versión al modelo registrado correspondiente.
-
-**Cómo se ve en MLFlow:**
-```
-Experimento: ml_pipeline_oil_and_gas
-  ├── Run: prod_gas_est50_depthNone_featall → versión 1 de oil_gas_prod_gas
-  ├── Run: prod_gas_est100_depth5_featall → versión 2 de oil_gas_prod_gas
-  ├── Run: prod_pet_est50_depthNone_featall → versión 1 de oil_gas_prod_pet
-  └── ...
-
-Model Registry:
-  ├── oil_gas_prod_gas → versiones 1 a 5
-  └── oil_gas_prod_pet → versiones 1 a 5
-```
-
+`evaluate_model` loguea en MLFlow las métricas `mae`, `mse`, `rmse` y `r2`, y registra el modelo en el Model Registry bajo `oil_gas_prod_gas` u `oil_gas_prod_pet`. También agrega tags y descripción a cada versión para que el Model Registry sea legible sin necesidad de abrir cada run.
 
 ### Task 7: `select_best_model`
 
-Consulta MLFlow y compara **todas las versiones históricas acumuladas** de cada modelo — no solo las de la corrida actual. Promueve la versión con mejor `r2` global con el alias `"production"`:
+Recibe los `run_id` de los experimentos del DAG actual, filtra las versiones del Model Registry por esos IDs, y promueve la de mejor R² con el alias `"production"`:
 
 - `oil_gas_prod_gas@production` → mejor modelo para gas
 - `oil_gas_prod_pet@production` → mejor modelo para petróleo
@@ -612,29 +509,19 @@ Consulta MLFlow y compara **todas las versiones históricas acumuladas** de cada
 
 ## Relación entre el entrenamiento y la API
 
-El rango de fechas elegido al triggerear el DAG condiciona directamente el comportamiento de la API. Entender esta relación es clave para interpretar correctamente las respuestas del endpoint `/forecast`.
-
-Cuando el DAG corre con `date_from=2023-01-01` y `date_to=2023-12-31`:
+El rango de fechas elegido al triggerear el DAG condiciona directamente el comportamiento de la API. Cuando el DAG corre con `date_from=2023-01-01` y `date_to=2023-12-31`:
 
 - El **parquet** contiene features históricos para todos los pozos entre enero y diciembre de 2023, más una fila futura por pozo (enero 2024) con `prod_gas = None`.
 - El **online store** queda con los features del estado más reciente de cada pozo — los correspondientes a diciembre 2023.
 - El **modelo** fue entrenado con datos de 2023.
 
-Esto define dos comportamientos en la API al momento de predecir:
-
-**Fechas dentro del período de entrenamiento (ej: 2023-03-01):** la API encuentra esa fecha en el parquet con datos reales y usa sus features. Cada mes tiene su propio `avg_prod_gas_10m` calculado con producción real, por lo que las predicciones varían mes a mes. Esto permite evaluar el comportamiento del modelo sobre datos conocidos, pero no constituye una predicción genuina del futuro.
-
-**Fechas posteriores al período de entrenamiento (ej: 2024-02-01):** la fecha no existe en el parquet (o existe como fila futura con target nulo). La API usa el online store — siempre los mismos features de diciembre 2023 — y devuelve la misma predicción para todos los meses del rango. Es el caso de uso principal del sistema: predecir producción futura a partir del estado más reciente del pozo.
-
-**Fechas anteriores al período de entrenamiento (ej: 2022-02-01):** la fecha no existe en el parquet (o existe como fila futura con target nulo). La API devuelve un error (HTTP 400) y no realiza la predicción.
-
-En resumen:
-
 | Fecha pedida | Fuente de features | Comportamiento |
 |---|---|---|
-| Anterior al período de entrenamiento | - | Error (no permitido) |
-| Dentro del período de entrenamiento | Offline store | Predicción basada en features históricos |
-| Posterior al período de entrenamiento | Online store | Predicción basada en el estado más reciente |
+| Anterior al período de entrenamiento | — | Error HTTP 400 (no permitido) |
+| Dentro del período de entrenamiento | Offline store (parquet) | Predicción distinta por mes usando features reales |
+| Posterior al período de entrenamiento | Online store (SQLite) | Misma predicción para todos los meses del rango |
+
+Para fechas futuras el modelo usa siempre los mismos features (estado de diciembre 2023) y devuelve la misma predicción para todos los meses — es una limitación del modelo single-step documentada en la decisión de diseño #8.
 
 ---
 
@@ -653,53 +540,20 @@ En resumen:
 
 **Funcionamiento:** genera el rango mensual entre `date_start` y `date_end` y para cada mes decide la fuente de features según la tabla de la sección anterior. Devuelve un punto por cada mes del rango.
 
-**Ejemplo de respuesta — 3 meses futuros (mismo valor repetido):**
+**Ejemplo de respuesta — 3 meses futuros:**
 ```json
 {
   "id_well": "3640",
   "data": [
-    {
-      "date": "2024-01-01",
-      "prod": 435.73
-    },
-    {
-      "date": "2024-02-01",
-      "prod": 435.73
-    },
-    {
-      "date": "2024-03-01",
-      "prod": 435.73
-    }
+    { "date": "2024-01-01", "prod": 435.73 },
+    { "date": "2024-02-01", "prod": 435.73 },
+    { "date": "2024-03-01", "prod": 435.73 }
   ]
 }
 ```
 
-Enero y febrero varían porque cada mes usa sus propios features históricos (producción real de los meses anteriores). A partir de marzo, el pozo no tiene más registros en el dataset: la API toma el estado más reciente del online store y repite la misma predicción para todos los meses futuros del rango.
-
-**Cómo identificar el límite en la respuesta:** el primer valor que se repite consecutivamente con el mismo número indica la transición del offline store al online store para ese pozo.
-
-**Decisión de diseño — predicción autoregresiva descartada:** Actualizar `avg_prod_10m` con valores predichos introduce distribution shift (el feature fue calculado sobre producción real en entrenamiento). En pozos shale con decline pronunciado, el error se autocorrela. La alternativa de repetir la misma predicción para fechas futuras es más honesta respecto a las limitaciones del modelo single-step.
-
-**Nota sobre consistencia del online store:** En versiones anteriores del código se observaba una diferencia llamativa entre la predicción del último mes histórico y la del primer mes futuro (online store), causada por datos rancios en el SQLite de corridas anteriores. Este comportamiento fue corregido: `prepare_offline_store` borra el registry y el SQLite antes de cada `feast apply`, garantizando que el online store siempre refleje el estado actual del parquet.
-
-**Limitación conocida — el modelo tiende a converger a la media del dataset para fechas futuras:** Al consultar fechas futuras (online store), pozos con perfiles muy distintos pueden recibir la misma predicción. Esto fue verificado empíricamente:
-
-| idpozo | avg_prod_gas_10m | last_prod_gas | pred online store |
-|--------|-----------------|---------------|-------------------|
-| 164588 | 15.263 Mm³ | 20.236 Mm³ | 611.19 |
-| 163700 | 15.579 Mm³ | 12.050 Mm³ | 611.19 |
-| 3640   | 7.5 Mm³    | 0.0 Mm³    | 611.19 |
-
-Los features del online store son correctos y distintos para cada pozo — el problema está en el modelo. RandomForest tiende a predecir valores cercanos a la media del dataset de entrenamiento cuando los inputs están fuera de la distribución vista durante el entrenamiento, o cuando el dataset de entrenamiento tiene alta concentración de filas en ese rango de producción. 611.19 es esencialmente el valor promedio de `prod_gas` en el dataset de entrenamiento.
-
-Esto es una limitación del modelo (no del pipeline) y tiene dos causas posibles:
-1. **Distribución sesgada del dataset:** la mayoría de los pozos en el dataset de entrenamiento producen en el rango 500-700 Mm³/mes, lo que ancla las predicciones del RandomForest hacia esa zona.
-2. **Features insuficientes para diferenciar pozos en el online store:** el modelo aprendió a distinguir pozos usando su historia reciente, pero cuando esa historia no está disponible (online store usa una sola fila), la capacidad discriminativa se reduce.
-
-Para la entrega final se evaluará si agregar features adicionales (formación geológica, empresa operadora, ubicación) o cambiar el modelo mejora la diferenciación en inferencia futura.
-
+**Limitación conocida:** con un dataset de entrenamiento de un solo año (2023), la capacidad discriminativa del modelo en inferencia futura es limitada. Incorporar el Dataset 2 (metadata extra por pozo) mejoraría la diferenciación entre pozos en inferencia futura.
 
 ### `GET /api/v1/wells`
 
-Devuelve el listado de pozos disponibles para una fecha dada (`date_query`). La fecha debe ser el primer día del mes (ej: `2023-01-01`) y debe estar dentro del período de entrenamiento — el endpoint consulta el parquet del offline store.
-
+Devuelve el listado de pozos disponibles para una fecha dada (`date_query`). La fecha debe ser el primer día del mes (ej: `2023-01-01`) y debe estar dentro del período de entrenamiento.

--- a/README.md
+++ b/README.md
@@ -342,6 +342,14 @@ En pozos no convencionales, la producción de gas y petróleo no siempre están 
 
 Para fechas futuras la API repite la misma predicción en lugar de actualizar `avg_prod_10m` con valores predichos. Alimentar el modelo con sus propias predicciones cambiaría la distribución del feature respecto al entrenamiento (distribution shift). En pozos shale con decline pronunciado, el error se autocorrelacionaría.
 
+### 9. Alineación entre entrenamiento e inferencia
+
+El modelo se entrena con features del mes T para predecir el target del mes T — por ejemplo, los features de marzo 2023 predicen la producción de marzo 2023. En inferencia, en cambio, se usan los features del último mes conocido (T) para predecir el mes siguiente (T+1).
+
+Esta asimetría significa que el modelo nunca aprendió explícitamente la relación T→T+1, sino T→T. La inferencia asume que el estado del mes más reciente es un proxy suficientemente bueno para predecir el mes siguiente — lo cual es razonable dado el comportamiento relativamente estable de la producción mensual en pozos no convencionales, pero es una limitación conocida del pipeline.
+
+Para resolverlo correctamente habría que entrenar con features de T y target de T+1, alineando el entrenamiento con el caso de uso real de inferencia.
+
 ---
 
 ## Feature Store

--- a/dags/dag_oil_and_gas.py
+++ b/dags/dag_oil_and_gas.py
@@ -145,12 +145,8 @@ def ml_pipeline():
     # Guardamos el DataFrame en formato parquet
     offline_feat_df.to_parquet(offline_parquet_path, index = False)
 
-    # Borramos el registry y el SQLite antes de feast apply para garantizar consistencia
-    # con el parquet actual. Feast no sobreescribe entradas del online store cuyo timestamp
-    # sea más reciente que el nuevo dato. Además, feast apply solo crea las tablas del
-    # online store si detecta cambios en el registry — si el registry existe y dice que
-    # la infraestructura ya está creada, no recrea las tablas aunque el SQLite no exista.
-    # Borrando ambos forzamos una instalación limpia en cada corrida del DAG.
+    # Feast no sobreescribe entradas con timestamp más viejo ni recrea tablas si el registry ya existe
+    # Borramos ambos para forzar una instalación limpia en cada corrida
     for path in [
         os.path.join(feature_store_repo, 'online_store/online.db'),
         os.path.join(feature_store_repo, 'registry/registry.db'),


### PR DESCRIPTION
Clari, le hice un par de cambios al README.

Saqué la deuda de Point-in-Time porque era incorrecta, get_historical_features de Feast ya hace eso, está documentado en el código mismo. Y saqué la tabla que mostraba los tres pozos prediciendo 611.19, era el bug de Feast que ya corregimos, no tenía sentido dejarlo como "limitación conocida".?

Corregí un par de sutilezas: "10 experimentos por target" era incorrecto, son 10 en total (5 por target). Y la sección de FTI decía que eran tres pipelines separados cuando en realidad están todos dentro de un solo DAG, lo aclaré y expliqué cómo sería en un sistema más maduro.

Reescribí la parte del Dataset 2, lo que aporta es metadata extra por pozo que no está en el Dataset 1, no "features estructurales". Y dejé claro que queda fuera del scope del TP porque el foco está en la arquitectura, no en optimizar el modelo.

Por último agregué una decisión de diseño nueva (la #9) sobre la alineación entre entrenamiento e inferencia. El modelo aprende T→T (features de marzo para predecir producción de marzo) pero en inferencia usamos los features de diciembre para predecir enero. Es una limitación real que vale documentar.