### PR TITLE
feat: servir la API con Ray Serve (FastAPI ingress, deployment unificado)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,6 @@ El sistema tarda aproximadamente 2-3 minutos en estar completamente operativo.
 | Airflow UI | http://localhost:8080 | airflow / airflow |
 | MLFlow UI | http://localhost:9090 | - |
 | API Swagger | http://localhost:8000/docs | - |
-| Ray Dashboard | http://localhost:8265 | - |
 
 ### 9. Nota sobre MLFlow y seguridad de red
 
@@ -462,14 +461,9 @@ El "parcial" del último escenario no refleja una falla del diseño: ocurre por 
 
 #### Observabilidad
 
-Ray expone un dashboard en [http://localhost:8265](http://localhost:8265) con métricas por deployment y por réplica (req/s, latencia, estado, logs). Se habilita inicializando Ray explícitamente antes de `serve.start()`:
+Ray expone un dashboard nativo en el puerto `8265` con métricas por deployment y por réplica. Se habilita inicializando Ray explícitamente antes de `serve.start()` con `ray.init(dashboard_host="0.0.0.0", include_dashboard=True)` y usando la instalación `ray[serve,default]` (el extra `default` trae las dependencias del UI).
 
-```python
-ray.init(dashboard_host="0.0.0.0", dashboard_port=8265, include_dashboard=True)
-serve.start(http_options={"host": "0.0.0.0", "port": 8000})
-```
-
-La instalación del container usa `ray[serve,default]` para incluir las dependencias del dashboard UI (el extra `default` trae `aiohttp`, `prometheus_client` y demás que el dashboard necesita).
+**No está habilitado en este despliegue local.** El overhead de memoria del dashboard (proceso de Ray Dashboard + métricas + deps adicionales) sumado al de `num_replicas=2` excede la RAM disponible en esta configuración de Docker Desktop y empuja a Ray a un loop de crash por OOM. El dashboard queda disponible en el código como opción, comentado; habilitarlo requiere entornos con más recursos o bajar a `num_replicas=1`.
 
 El script [`api/load_test.py`](api/load_test.py) permite reproducir los tres escenarios de carga (baseline, pico, pico sostenido) para medir regresiones o cambios de configuración contra el mismo baseline.
 

--- a/README.md
+++ b/README.md
@@ -462,7 +462,14 @@ El "parcial" del último escenario no refleja una falla del diseño: ocurre por 
 
 #### Observabilidad
 
-Ray expone un dashboard en `http://localhost:8265` con métricas por deployment y por réplica. Cuando Ray se arranca programáticamente con `serve.start()` el dashboard no queda habilitado por default; habilitarlo requiere inicializar con `ray.init(dashboard_host="0.0.0.0")`, mejora que queda como follow-up de observabilidad.
+Ray expone un dashboard en [http://localhost:8265](http://localhost:8265) con métricas por deployment y por réplica (req/s, latencia, estado, logs). Se habilita inicializando Ray explícitamente antes de `serve.start()`:
+
+```python
+ray.init(dashboard_host="0.0.0.0", dashboard_port=8265, include_dashboard=True)
+serve.start(http_options={"host": "0.0.0.0", "port": 8000})
+```
+
+La instalación del container usa `ray[serve,default]` para incluir las dependencias del dashboard UI (el extra `default` trae `aiohttp`, `prometheus_client` y demás que el dashboard necesita).
 
 El script [`api/load_test.py`](api/load_test.py) permite reproducir los tres escenarios de carga (baseline, pico, pico sostenido) para medir regresiones o cambios de configuración contra el mismo baseline.
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ El sistema tarda aproximadamente 2-3 minutos en estar completamente operativo.
 | Airflow UI | http://localhost:8080 | airflow / airflow |
 | MLFlow UI | http://localhost:9090 | - |
 | API Swagger | http://localhost:8000/docs | - |
+| Ray Dashboard | http://localhost:8265 | - |
 
 ### 9. Nota sobre MLFlow y seguridad de red
 
@@ -349,6 +350,42 @@ El modelo se entrena con features del mes T para predecir el target del mes T �
 Esta asimetría significa que el modelo nunca aprendió explícitamente la relación T→T+1, sino T→T. La inferencia asume que el estado del mes más reciente es un proxy suficientemente bueno para predecir el mes siguiente — lo cual es razonable dado el comportamiento relativamente estable de la producción mensual en pozos no convencionales, pero es una limitación conocida del pipeline.
 
 Para resolverlo correctamente habría que entrenar con features de T y target de T+1, alineando el entrenamiento con el caso de uso real de inferencia.
+
+### 10. Arquitectura de serving: Ray Serve con FastAPI y deployment unificado
+
+**Contexto:** la API de inferencia corría como un único proceso `uvicorn` sin escalado horizontal y cargaba los modelos desde MLFlow en **cada request**. Eso acumula dos problemas: imposibilidad de escalar para atender picos de demanda, y latencia inflada por recargar el modelo en cada llamada.
+
+**Framework elegido: Ray Serve con FastAPI como ingress.** Ray Serve permite escalado horizontal declarativo (réplicas + balanceo) sin salir del ecosistema Python. Se envuelve la `app` de FastAPI existente con `@serve.ingress(app)`, preservando el contrato público (endpoints, query params, Swagger en `/docs`) y permitiendo a los consumidores seguir usando la API sin cambios. Alternativas descartadas: `uvicorn --workers` (escala procesos pero no resuelve el costo de cargar el modelo por request), TensorFlow Serving (fuerza formato TF y agrega un lenguaje distinto), SageMaker / Vertex AI (serving cloud gestionado, fuera del alcance de un TP local).
+
+**Deployment unificado con ambos modelos en la misma clase.** La clase `APIDeployment` carga en `__init__` tanto el modelo de gas como el de petróleo, y despacha según el param `target` del request. La alternativa era dos deployments separados (uno por target). Se descarta esta última por:
+
+1. **Eficiencia de memoria.** El overhead fijo de cada réplica de Ray Serve (≈100 MB por scheduler, proxy y state) domina sobre el tamaño de cada modelo `RandomForest` (≈20-50 MB). Con deployment unificado y 2 réplicas total quedan 2 workers; con 2 deployments × 2 réplicas c/u serían 4 workers → más memoria sin beneficio de capacidad. En un entorno con 9 contenedores compartiendo RAM, el ahorro importa.
+2. **Ausencia de evidencia empírica de asimetría de carga gas/pet.** Separar deployments tiene sentido cuando los targets tienen patrones de demanda muy distintos (uno saturado, el otro ocioso). Hoy no hay forma de medir eso: la API no tiene prediction log persistente (ver pendiente relacionado con monitoreo de producción). La distribución del dataset sugiere más pozos gasíferos que petrolíferos, pero es un proxy del dominio, no del uso real.
+3. **Simplicidad operativa.** Un único deployment tiene un único ciclo de vida, una única config de réplicas, un único lugar donde revisar logs y métricas.
+
+Si en el futuro el prediction log muestra asimetría sostenida (≥3× de tráfico en un target, o latencia p95 degradada en uno mientras el otro tiene capacidad ociosa), se separa en dos deployments con handles independientes.
+
+**Configuración inicial:**
+
+- `num_replicas=2`. Dos réplicas permiten paralelizar inferencia y tolerar la caída de una sin quedarse sin servicio, sin saturar la memoria del host local.
+- `max_queued_requests=30`. Sin este límite, bajo carga alta Ray encola requests indefinidamente: el servicio nunca devuelve error pero la latencia p95 se degrada a segundos. Con el límite, cuando la cola se llena el servicio responde `503` a los requests excedentes, preservando latencia para los que sí entran. Es un trade-off deliberado entre latencia y tasa de error bajo pico.
+- **Modelos cargados una vez por réplica en `__init__`.** El `mlflow.sklearn.load_model(...)` se ejecuta al crear la réplica, no por request. Además del escalado, esto elimina por sí solo el overhead de recarga que tenía la implementación previa.
+- **Feature store client (`FeatureStore`) también inicializado una vez por réplica**, por el mismo motivo.
+
+**SLA objetivo** (validado por load test):
+
+| Escenario | Objetivo |
+|---|---|
+| Carga normal (50 req/s, 5s) | p95 < 500 ms, error rate 0 % |
+| Pico (140 req/s, 5s) | p95 controlado por `max_queued_requests` |
+| Pico sostenido (140 req/s, 30s) | Throughput ≥ 100 req/s exitosos, sin colapso por cola infinita |
+
+**Observabilidad:** Ray expone un dashboard en el puerto `8265` (`http://localhost:8265`) con métricas por deployment y por réplica (req/s, latencia, estado, logs). Es el canal para detectar más adelante la asimetría de carga gas/pet que hoy no se puede medir.
+
+**Trade-offs pendientes de evaluar con datos reales:**
+
+- Réplicas fijas vs. autoscaling dinámico con `autoscaling_config` de Ray: simplicidad y predictibilidad frente a elasticidad bajo demanda variable. Hoy no hay data suficiente para justificar autoscaling; queda como posible evolución.
+- Cache de inferencia (ej. Redis) para queries repetitivas de los mismos pozos: optimización posible si el tráfico real muestra concentración en pocos pozos "hot". Actualmente no se implementa.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -351,41 +351,134 @@ Esta asimetría significa que el modelo nunca aprendió explícitamente la relac
 
 Para resolverlo correctamente habría que entrenar con features de T y target de T+1, alineando el entrenamiento con el caso de uso real de inferencia.
 
-### 10. Arquitectura de serving: Ray Serve con FastAPI y deployment unificado
+### 10. Arquitectura de serving: Ray Serve con FastAPI
 
-**Contexto:** la API de inferencia corría como un único proceso `uvicorn` sin escalado horizontal y cargaba los modelos desde MLFlow en **cada request**. Eso acumula dos problemas: imposibilidad de escalar para atender picos de demanda, y latencia inflada por recargar el modelo en cada llamada.
+La inferencia del modelo debe responder a consultas externas con latencia acotada, escalar ante picos de demanda, tolerar la caída de una instancia sin perder servicio, y no pagar el costo de cargar el modelo desde MLFlow en cada request. La implementación más simple (un proceso uvicorn único) no provee ninguna de esas propiedades. Se necesita un framework que separe el servidor HTTP del ciclo de vida del modelo, permita escalado horizontal declarativo, y gestione fallos automáticamente.
 
-**Framework elegido: Ray Serve con FastAPI como ingress.** Ray Serve permite escalado horizontal declarativo (réplicas + balanceo) sin salir del ecosistema Python. Se envuelve la `app` de FastAPI existente con `@serve.ingress(app)`, preservando el contrato público (endpoints, query params, Swagger en `/docs`) y permitiendo a los consumidores seguir usando la API sin cambios. Alternativas descartadas: `uvicorn --workers` (escala procesos pero no resuelve el costo de cargar el modelo por request), TensorFlow Serving (fuerza formato TF y agrega un lenguaje distinto), SageMaker / Vertex AI (serving cloud gestionado, fuera del alcance de un TP local).
+#### Qué es Ray Serve y por qué se eligió
 
-**Deployment unificado con ambos modelos en la misma clase.** La clase `APIDeployment` carga en `__init__` tanto el modelo de gas como el de petróleo, y despacha según el param `target` del request. La alternativa era dos deployments separados (uno por target). Se descarta esta última por:
+[Ray Serve](https://docs.ray.io/en/latest/serve/index.html) es un framework de model serving distribuido construido sobre Ray Core. Su arquitectura interna tiene tres tipos de actores:
 
-1. **Eficiencia de memoria.** El overhead fijo de cada réplica de Ray Serve (≈100 MB por scheduler, proxy y state) domina sobre el tamaño de cada modelo `RandomForest` (≈20-50 MB). Con deployment unificado y 2 réplicas total quedan 2 workers; con 2 deployments × 2 réplicas c/u serían 4 workers → más memoria sin beneficio de capacidad. En un entorno con 9 contenedores compartiendo RAM, el ahorro importa.
-2. **Ausencia de evidencia empírica de asimetría de carga gas/pet.** Separar deployments tiene sentido cuando los targets tienen patrones de demanda muy distintos (uno saturado, el otro ocioso). Hoy no hay forma de medir eso: la API no tiene prediction log persistente (ver pendiente relacionado con monitoreo de producción). La distribución del dataset sugiere más pozos gasíferos que petrolíferos, pero es un proxy del dominio, no del uso real.
-3. **Simplicidad operativa.** Un único deployment tiene un único ciclo de vida, una única config de réplicas, un único lugar donde revisar logs y métricas.
+- **Controller:** actor global del plano de control. Crea, actualiza y destruye réplicas, y corre el autoscaler. Es el componente responsable de la fault tolerance: si una réplica muere, el Controller la recrea automáticamente.
+- **HTTP Proxy:** actores que reciben el tráfico entrante y lo enrutan a las réplicas con round-robin y backpressure. Se pueden correr uno por nodo para alta disponibilidad.
+- **Replicas:** actores que ejecutan el código del deployment — en este proyecto, los que cargan los modelos y corren la inferencia.
 
-Si en el futuro el prediction log muestra asimetría sostenida (≥3× de tráfico en un target, o latencia p95 degradada en uno mientras el otro tiene capacidad ociosa), se separa en dos deployments con handles independientes.
+Se eligió Ray Serve sobre alternativas por dos razones concretas:
 
-**Configuración inicial:**
+1. **Integración con FastAPI preservando el contrato público.** `@serve.ingress(app)` envuelve la `app` de FastAPI: los endpoints, query params, validación de tipos y Swagger siguen funcionando sin modificación del cliente. Otras alternativas fuerzan cambios: TensorFlow Serving obliga al formato TF y a un protocolo específico, Triton requiere un modelo repository con convenciones rígidas, SageMaker / Vertex AI son gestionados cloud (fuera del alcance local).
+2. **Escalado horizontal declarativo.** Aumentar capacidad es una línea: `num_replicas=N` o un bloque de `autoscaling_config`. No hay que reescribir la API ni tocar el cliente.
 
-- `num_replicas=2`. Dos réplicas permiten paralelizar inferencia y tolerar la caída de una sin quedarse sin servicio, sin saturar la memoria del host local.
-- `max_queued_requests=30`. Sin este límite, bajo carga alta Ray encola requests indefinidamente: el servicio nunca devuelve error pero la latencia p95 se degrada a segundos. Con el límite, cuando la cola se llena el servicio responde `503` a los requests excedentes, preservando latencia para los que sí entran. Es un trade-off deliberado entre latencia y tasa de error bajo pico.
-- **Modelos cargados una vez por réplica en `__init__`.** El `mlflow.sklearn.load_model(...)` se ejecuta al crear la réplica, no por request. Además del escalado, esto elimina por sí solo el overhead de recarga que tenía la implementación previa.
-- **Feature store client (`FeatureStore`) también inicializado una vez por réplica**, por el mismo motivo.
+#### Cómo está implementado en este proyecto
 
-**SLA objetivo** (validado por load test):
+La clase [`APIDeployment`](api/main.py) está decorada con `@serve.deployment(...)` + `@serve.ingress(app)`:
 
-| Escenario | Objetivo |
+- **`__init__` carga el estado pesado una sola vez por réplica**: ambos modelos desde MLFlow (`oil_gas_prod_gas@production` y `oil_gas_prod_pet@production`) y el cliente de Feast. El `mlflow.sklearn.load_model(...)` ocurre al crear la réplica — nunca dentro del handler. Esto desacopla el costo de carga del costo por request.
+- **Los handlers** (`get_wells`, `get_forecast`) son métodos de la clase y consumen `self.model_gas`, `self.model_pet`, `self.store`.
+- **Arranque programático** en `if __name__ == "__main__"`: `serve.start(http_options={...})` + `serve.run(app_deployment)`. Docker ejecuta `python -m api.main`. Se evita depender del CLI `serve run`, cuyos flags de host/port cambian entre versiones de Ray.
+
+#### Cómo cumple estándares de escalabilidad
+
+| Propiedad | Implementación en este proyecto |
 |---|---|
-| Carga normal (50 req/s, 5s) | p95 < 500 ms, error rate 0 % |
-| Pico (140 req/s, 5s) | p95 controlado por `max_queued_requests` |
-| Pico sostenido (140 req/s, 30s) | Throughput ≥ 100 req/s exitosos, sin colapso por cola infinita |
+| **Escalado horizontal** | `num_replicas` declarativo. Réplicas stateless (cualquiera atiende cualquier request). Escalable sin cambios en el cliente. |
+| **Load balancing automático** | El HTTP Proxy distribuye requests en round-robin entre réplicas, respetando `max_ongoing_requests` por réplica (backpressure a nivel de handle). |
+| **Graceful degradation** | `max_queued_requests=30` hace que, bajo saturación, Ray rechace nuevos requests con `503` en vez de dejarlos en cola infinita. Preserva la latencia de los que sí entran y acota el tiempo máximo de espera. |
+| **Fault tolerance** | El Controller monitorea el estado de las réplicas y las recrea automáticamente si mueren. Observado empíricamente en el escenario sostenido del load test: Ray mató workers por OOM y los reemplazó. |
+| **Autoscaling disponible** | Sustituir `num_replicas=N` por `autoscaling_config={min,max,target}` habilita escalado reactivo a carga observada. No se implementa ahora (ver [#28](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/28)) pero el código está preparado para activarlo sin rediseño. |
+| **Observabilidad nativa** | Ray expone un dashboard con métricas por deployment y por réplica (req/s, latencia, estado, logs) en el puerto `8265`. Diagnóstico in situ sin instrumentación adicional. |
+| **Inmutabilidad** | El deployment es una clase serializable con estado inicializado en `__init__`. Cualquier cambio crea una nueva versión del deployment; no hay mutación de estado en runtime. Alineado con el principio de "contenedores y modelos inmutables en producción". |
 
-**Observabilidad:** Ray expone un dashboard en el puerto `8265` (`http://localhost:8265`) con métricas por deployment y por réplica (req/s, latencia, estado, logs). Es el canal para detectar más adelante la asimetría de carga gas/pet que hoy no se puede medir.
+#### Dos dimensiones de escalado: réplicas y deployments
 
-**Trade-offs pendientes de evaluar con datos reales:**
+Ray Serve permite escalar en **dos dimensiones independientes** que es importante no mezclar:
 
-- Réplicas fijas vs. autoscaling dinámico con `autoscaling_config` de Ray: simplicidad y predictibilidad frente a elasticidad bajo demanda variable. Hoy no hay data suficiente para justificar autoscaling; queda como posible evolución.
-- Cache de inferencia (ej. Redis) para queries repetitivas de los mismos pozos: optimización posible si el tráfico real muestra concentración en pocos pozos "hot". Actualmente no se implementa.
+- **Réplicas (`num_replicas`)**: cuántas **copias del mismo deployment** corren en paralelo. Cada réplica es un worker independiente con su propio estado inicializado en `__init__`. El HTTP Proxy distribuye los requests entre ellas. Agregar réplicas aumenta paralelismo y tolerancia a fallos — si una cae, las otras siguen atendiendo.
+
+- **Deployments separados**: **clases distintas** de deployment, cada una con su propio ciclo de vida y su propio pool de réplicas. Se usan cuando los componentes son lógicamente diferentes (ej. clasificación vs. ranking), o cuando se quiere escalar cada pool de forma independiente.
+
+Para este proyecto la pregunta concreta es: tenemos dos modelos (gas y petróleo) → ¿un único deployment unificado que carga ambos, o dos deployments separados?
+
+#### Decisión: deployment unificado con `num_replicas=2`
+
+Comparando las tres arquitecturas candidatas, con memoria estimada (≈100 MB de overhead por réplica de Ray + ≈30 MB por modelo `RandomForest`):
+
+| Arquitectura | Workers | Memoria aprox. | Paralelismo efectivo |
+|---|---|---|---|
+| **Unificado, `num_replicas=2` (elegida)** | 2 | 2 × (100 + 60) = **320 MB** | 2 requests en paralelo de cualquier combinación de fluidos |
+| Separado, 1 réplica por fluido | 2 | 2 × (100 + 30) = **260 MB** | 1 request de gas + 1 de petróleo simultáneos, no balanceable entre sí |
+| Separado, 2 réplicas por fluido | 4 | 4 × (100 + 30) = **520 MB** | 4 requests (2 por fluido), balanceados solo dentro de cada fluido |
+
+**Por qué `num_replicas=2` unificado es el punto óptimo**:
+
+1. **Por qué no 1 réplica unificada.** Con una sola réplica se pierde *fault tolerance*: si muere (OOM, excepción, deploy), el servicio queda caído hasta que el Controller la recree. Con 2 réplicas, mientras una se recrea la otra sigue atendiendo. El costo de esta garantía es ≈160 MB adicionales — es el costo de tener alta disponibilidad.
+2. **Por qué no separar en dos deployments.**
+   - **Separado con 1 réplica por fluido (260 MB, el más chico)**: pierde balanceo entre fluidos. Si llegan 2 requests de gas simultáneos, el único worker de gas se satura aunque el worker de petróleo esté ocioso. Unificado los distribuye.
+   - **Separado con 2 réplicas por fluido (520 MB)**: la alternativa más cara. Duplica la memoria sin beneficio claro **mientras no haya evidencia de asimetría de carga sostenida entre gas y petróleo**. Esa evidencia requeriría prediction logging persistente, todavía no implementado. Decidir separar sin esa data sería especulativo — criterio para re-evaluar documentado en [#26](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/26).
+3. **Por qué no más de 2 réplicas unificadas.** En este entorno local, con 9 containers compartiendo la RAM de la VM de Docker, no hay headroom para una tercera réplica sin empujar al OOM — el load test ya muestra OOM con 2. En un entorno productivo con recursos adecuados, escalar a 3+ es simplemente subir el valor del param.
+
+La elección unificado + 2 réplicas es entonces el **punto óptimo entre memoria, paralelismo y disponibilidad** dadas las restricciones reales del entorno, y se mantiene abierto el camino para reconfigurarlo data-driven cuando haya evidencia real.
+
+#### Configuración elegida
+
+- `num_replicas=2`. Justificación arriba.
+- `max_queued_requests=30`. Sin este límite, bajo carga alta Ray encola requests indefinidamente: el servicio nunca devuelve error pero la latencia p95 se degrada a segundos y el tiempo máximo de espera no está acotado. Con el límite, cuando la cola se llena el servicio responde `503` a los requests excedentes, preservando latencia para los que sí entran. Es un trade-off deliberado entre latencia y tasa de error bajo pico — en la industria del serving se le llama *graceful degradation*.
+- **Modelos y feature store cargados una vez por réplica en `__init__`** — desacopla costo de carga del costo por request.
+
+#### SLAs: dos niveles
+
+El sistema se diseñó con dos SLAs en mente, porque el objetivo del TP (mostrar el diseño) y las mediciones empíricas (limitadas por el entorno local) requieren diferenciarse.
+
+**SLA productivo esperado — industria oil & gas**
+
+El perfil de uso de este modelo **no** es real-time user-facing. Los consumidores típicos son:
+
+- **Analistas de producción** consultando pronósticos mensuales ocasionalmente → latencia p95 < 2 s aceptable, < 5 s tolerable.
+- **Dashboards de BI y reportes de operaciones** (actualización horaria o diaria) → latencia no crítica, throughput sostenido bajo.
+- **Sistemas de planificación operacional y allocation** (integración batch o scheduled) → throughput sobre latencia.
+
+El volumen de tráfico sostenido en una operadora mediana es bajo (unidades de req/s), con picos esporádicos al cerrar mes o generar reportes. Difiere radicalmente de IoT industrial real-time, donde la [literatura sugiere SLAs de 100-500 ms](https://dspace.networks.imdea.org/bitstream/handle/20.500.12761/1958/Exploring_the_Boundaries_of_On_Device_Inference__When_Tiny_Falls_Short__Go_Hierarchical%20(1).pdf?sequence=1) porque alimentan loops de control cerrado. Aquí la inferencia alimenta decisiones humanas con horizonte mensual: la latencia tolerable es órdenes de magnitud mayor.
+
+Target productivo razonable:
+
+| Métrica | Objetivo productivo |
+|---|---|
+| Latencia p95 | < 2 s |
+| Throughput sostenido | ≥ 100 req/s |
+| Disponibilidad | ≥ 99,5 % |
+| Error rate en operación normal | < 1 % |
+
+**SLA adaptado al entorno local (el que efectivamente validamos)**
+
+Los recursos disponibles (Mac Intel, Docker Desktop con RAM limitada, 9 containers compartiendo CPU) no permiten cumplir el SLA productivo. El objetivo del SLA local es distinto: **demostrar que el diseño se comporta coherentemente bajo carga y protege al sistema del colapso**, no alcanzar métricas productivas absolutas.
+
+| Métrica | Objetivo local | Resultado observado | ✓/✗ |
+|---|---|---|---|
+| Throughput sostenido (carga baseline 50 req/s) | ≥ 20 req/s exitosos | 26,4 req/s | ✓ |
+| Latencia p95 en baseline | < 3 s | 2,7 s | ✓ |
+| Rechazo controlado bajo pico (140 req/s, 5 s) | `503` por cola llena, sin colapso | 398 × `503` esperados | ✓ |
+| Degradación manejada bajo pico sostenido (140 req/s, 30 s) | Servicio sigue respondiendo | Servicio disponible pero con OOM (268 × `500`) | parcial |
+
+El "parcial" del último escenario no refleja una falla del diseño: ocurre por presión de memoria del entorno local (Ray mata réplicas por OOM y no alcanza a recrearlas a tiempo bajo carga sostenida). En producción con recursos adecuados por réplica no debería reproducirse — el *fault tolerance* de Ray Serve recupera las réplicas, pero necesita tiempo y headroom de memoria para hacerlo.
+
+#### Observabilidad
+
+Ray expone un dashboard en `http://localhost:8265` con métricas por deployment y por réplica. Cuando Ray se arranca programáticamente con `serve.start()` el dashboard no queda habilitado por default; habilitarlo requiere inicializar con `ray.init(dashboard_host="0.0.0.0")`, mejora que queda como follow-up de observabilidad.
+
+El script [`api/load_test.py`](api/load_test.py) permite reproducir los tres escenarios de carga (baseline, pico, pico sostenido) para medir regresiones o cambios de configuración contra el mismo baseline.
+
+#### Trade-offs pendientes de evaluar con datos reales
+
+- **Réplicas fijas vs. autoscaling dinámico** con `autoscaling_config`: simplicidad y predictibilidad frente a elasticidad bajo demanda variable — [#28](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/28).
+- **Cache de inferencia** (ej. Redis) para queries repetitivas sobre los mismos pozos — [#27](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/27).
+- **Separación de deployments gas / petróleo** si el prediction log muestra asimetría de carga sostenida — [#26](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/26).
+
+#### Referencias
+
+- [Ray Serve Architecture](https://docs.ray.io/en/latest/serve/architecture.html) — componentes del runtime (Controller, HTTP Proxy, Replicas) y mecanismos de escalado horizontal.
+- [Ray Serve Autoscaling Guide](https://docs.ray.io/en/latest/serve/autoscaling-guide.html) — política de autoscaling reactivo basada en métricas del deployment handle.
+- [Ray Serve — Scalable and Programmable Serving](https://docs.ray.io/en/latest/serve/index.html) — integración con FastAPI, composición de deployments, features de alto nivel.
+- [IMDEA Networks — Exploring the Boundaries of On-Device Inference (2024)](https://dspace.networks.imdea.org/bitstream/handle/20.500.12761/1958/Exploring_the_Boundaries_of_On_Device_Inference__When_Tiny_Falls_Short__Go_Hierarchical%20(1).pdf?sequence=1) — latencias típicas en ML inference para casos IoT industrial (100-500 ms), útil para ubicar dónde ese rango aplica y dónde el caso de uso admite latencias mayores.
+- [MLSysBook — Benchmarking in Performance Engineering](https://mlsysbook.ai/contents/core/benchmarking/benchmarking.html) — estándares de benchmarking (p50, p95, p99) y definición de SLAs para sistemas de ML en producción.
 
 ---
 

--- a/api/load_test.py
+++ b/api/load_test.py
@@ -1,0 +1,122 @@
+"""
+Load test del endpoint /api/v1/forecast servido con Ray Serve.
+
+Envía `RATE` requests por segundo durante `TEST_DURATION_S` segundos y reporta
+throughput, distribución de latencia (avg, p50, p95, p99, max), y tasa de error
+(5xx + excepciones). La medición de latencia se hace solo sobre requests exitosos (200).
+
+Decisiones de diseño del script:
+
+    - Variables de entorno para configurar RATE, TEST_DURATION_S, URL, etc.:
+      permite correr distintos escenarios (valle, pico, pico sostenido) sin editar el archivo.
+    - Seed fija de `random`: los pozos y targets elegidos son los mismos en cada corrida
+      con la misma configuración, de forma que dos ejecuciones del test son directamente
+      comparables (la variabilidad restante viene del sistema, no del test).
+    - Pozos e inputs tomados del parquet del feature store: cada request ejerce inferencia
+      real contra modelos y online store, no un payload sintético.
+    - Validación temprana del rango de fechas: si el parquet actual no tiene datos en
+      `[DATE_START, DATE_END]`, el script aborta antes de disparar requests y explica cómo
+      resolver (en vez de reportar 404 masivo).
+
+Uso:
+    python api/load_test.py
+
+Configuración por variables de entorno (opcionales):
+    RATE=50                    # requests por segundo
+    TEST_DURATION_S=5          # duración del test en segundos
+    URL=http://localhost:8000/api/v1/forecast
+    DATE_START=2019-07-01
+    DATE_END=2019-09-01
+    PARQUET_PATH=feature_store/data/well_features.parquet
+"""
+import asyncio
+import os
+import random
+import statistics
+import time
+from collections import Counter
+
+import aiohttp
+import numpy as np
+import pandas as pd
+
+RATE = int(os.getenv("RATE", "50"))
+TEST_DURATION_S = int(os.getenv("TEST_DURATION_S", "5"))
+REQUESTS = int(RATE * TEST_DURATION_S)
+URL = os.getenv("URL", "http://localhost:8000/api/v1/forecast")
+DATE_START = os.getenv("DATE_START", "2019-07-01")
+DATE_END = os.getenv("DATE_END", "2019-09-01")
+PARQUET_PATH = os.getenv("PARQUET_PATH", "feature_store/data/well_features.parquet")
+
+# Seed fija: la misma corrida sobre el mismo parquet produce inputs idénticos request a request
+random.seed(204)
+
+# Cargamos pozos disponibles desde el parquet actual
+df = pd.read_parquet(PARQUET_PATH)
+WELL_IDS = df["idpozo"].unique().tolist()
+TARGETS = ["gas", "pet"]
+
+# Validación temprana: si el parquet no cubre [DATE_START, DATE_END], el test daría 404 masivo
+fechas = pd.to_datetime(df["fecha"])
+if not ((fechas >= DATE_START) & (fechas <= DATE_END)).any():
+    raise SystemExit(
+        f"El parquet actual no tiene datos entre {DATE_START} y {DATE_END}.\n"
+        f"Rango disponible en el parquet: {fechas.min().date()} → {fechas.max().date()}.\n"
+        f"Re-ejecutar el DAG con un rango compatible, o pasar DATE_START / DATE_END por env var."
+    )
+
+
+def params():
+    return {
+        "id_well": str(random.choice(WELL_IDS)),
+        "date_start": DATE_START,
+        "date_end": DATE_END,
+        "target": random.choice(TARGETS),
+    }
+
+
+async def send(session, ok, fail):
+    t0 = time.perf_counter()
+    try:
+        async with session.get(URL, params = params()) as r:
+            await r.read()
+            ok.append((r.status, (time.perf_counter() - t0) * 1000))
+    except Exception:
+        fail.append((time.perf_counter() - t0) * 1000)
+
+
+async def main():
+    ok, fail = [], []
+    t0 = time.perf_counter()
+    async with aiohttp.ClientSession(connector = aiohttp.TCPConnector(limit = 500)) as s:
+        tasks = []
+        for _ in range(REQUESTS):
+            tasks.append(asyncio.create_task(send(s, ok, fail)))
+            await asyncio.sleep(1 / RATE)
+        await asyncio.gather(*tasks)
+    elapsed = time.perf_counter() - t0
+
+    # Latencias solo para requests exitosos (200)
+    lat_ok = [ms for status, ms in ok if status == 200]
+    codes = Counter(c for c, _ in ok)
+
+    print("=" * 55)
+    print(f"Enviando {RATE} req/s por {TEST_DURATION_S} segundos.")
+    print("=" * 55)
+    print(f"Throughput (exitosos): {len(lat_ok) / elapsed:.1f} req/s")
+    if lat_ok:
+        print(f"avg={statistics.mean(lat_ok):.0f}ms")
+        print(f"p50={np.percentile(lat_ok, 50):.0f}ms")
+        print(f"p95={np.percentile(lat_ok, 95):.0f}ms")
+        print(f"p99={np.percentile(lat_ok, 99):.0f}ms")
+        print(f"max={max(lat_ok):.0f}ms")
+    else:
+        print("-> (Ningún request exitoso para medir latencia)")
+
+    errors_5xx = sum(v for k, v in codes.items() if int(k) >= 500)
+    error_pct = 100 * (len(fail) + errors_5xx) / REQUESTS if REQUESTS else 0
+    print(f"HTTP: {dict(codes)}  ( error rate: {error_pct:.1f}% )")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/api/main.py
+++ b/api/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, HTTPException
 from feast import FeatureStore
+from ray import serve
 import mlflow.sklearn
 import pandas as pd
 import os
@@ -17,137 +18,163 @@ app = FastAPI(
     description = "API simple para consultar el listado de pozos y sus pronósticos de producción."
 )
 
-# -------------------- ENDPOINTS --------------------
+# -------------------- DEPLOYMENT --------------------
 
-@app.get("/api/v1/wells")
-def get_wells(date_query: str):
+@serve.deployment(
+    num_replicas = 2,            # Dos réplicas permiten paralelizar inferencia sin explotar memoria local
+    max_queued_requests = 30,    # Límite de cola: bajo saturación devuelve 503 en vez de degradar latencia
+)
+@serve.ingress(app)
+class APIDeployment:
     """
-    Devuelve el listado de pozos que tienen registros para la fecha dada.
-    La fecha debe ser el primer día del mes (ej: 2022-01-01).
+    Deployment unificado con ambos modelos (gas y petróleo) cargados en memoria.
+    Los modelos y el feature store se inicializan una vez por réplica,
+    eliminando el overhead de cargarlos en cada request.
+
+    Ver "Decisiones de diseño → Arquitectura de serving" en el README.
     """
-    try:
-        # Leemos el parquet del offline store (una fila por pozo por mes)
-        df = pd.read_parquet(PARQUET_PATH)
-        df['fecha'] = pd.to_datetime(df['fecha'])
-        date = pd.to_datetime(date_query)
 
-        # Filtramos por fecha exacta y devolvemos los IDs únicos
-        pozos = df[df['fecha'] == date]['idpozo'].unique().tolist()
+    def __init__(self):
+        # Cargamos ambos modelos desde MLFlow una sola vez por réplica
+        self.model_gas = mlflow.sklearn.load_model("models:/oil_gas_prod_gas@production")
+        self.model_pet = mlflow.sklearn.load_model("models:/oil_gas_prod_pet@production")
 
-        if not pozos:
-            raise HTTPException(status_code = 404, detail = f"No se encontraron pozos para la fecha {date_query}")
+        # Feature store client también reutilizable entre requests
+        self.store = FeatureStore(repo_path = FEATURE_STORE_REPO)
 
-        return [{"id_well": str(p)} for p in pozos]
+    # -------------------- ENDPOINTS --------------------
 
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code = 500, detail = str(e))
+    @app.get("/api/v1/wells")
+    def get_wells(self, date_query: str):
+        """
+        Devuelve el listado de pozos que tienen registros para la fecha dada.
+        La fecha debe ser el primer día del mes (ej: 2022-01-01).
+        """
+        try:
+            # Leemos el parquet del offline store (una fila por pozo por mes)
+            df = pd.read_parquet(PARQUET_PATH)
+            df['fecha'] = pd.to_datetime(df['fecha'])
+            date = pd.to_datetime(date_query)
 
-@app.get("/api/v1/forecast")
-def get_forecast(id_well: str, date_start: str, date_end: str, target: str = "gas"):
-    """
-    Devuelve el pronóstico de producción de un pozo para cada mes entre date_start y date_end.
+            # Filtramos por fecha exacta y devolvemos los IDs únicos
+            pozos = df[df['fecha'] == date]['idpozo'].unique().tolist()
 
-        - Para fechas históricas con datos reales usa los features del offline store (parquet).
+            if not pozos:
+                raise HTTPException(status_code = 404, detail = f"No se encontraron pozos para la fecha {date_query}")
 
-        - Para fechas futuras o la fila futura del parquet (target nulo) usa el online store.
+            return [{"id_well": str(p)} for p in pozos]
 
-    No se hace actualización autoregresiva para evitar distribution shift en avg_prod_10m.
-    """
-    try:
-        if target not in ("gas", "pet"):
-            raise HTTPException(status_code = 400, detail = "target debe ser 'gas' o 'pet'")
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(status_code = 500, detail = str(e))
 
-        # Definimos la columna target y los features según el fluido a predecir
-        target_col = 'prod_gas' if target == 'gas' else 'prod_pet'
+    @app.get("/api/v1/forecast")
+    def get_forecast(self, id_well: str, date_start: str, date_end: str, target: str = "gas"):
+        """
+        Devuelve el pronóstico de producción de un pozo para cada mes entre date_start y date_end.
 
-        if target == "gas": # Cada target usa sus propios features de ventana porque gas y petróleo no siempre están correlacionados en pozos no convencionales
-            feature_cols = ['tipoextraccion', 'tef', 'profundidad', 'prod_agua',
-                            'avg_prod_gas_10m', 'last_prod_gas', 'n_readings']
-            # El alias @production apunta al modelo con mejor r2, promovido por select_best_model
-            model = mlflow.sklearn.load_model("models:/oil_gas_prod_gas@production")
-        else:
-            feature_cols = ['tipoextraccion', 'tef', 'profundidad', 'prod_agua',
-                            'avg_prod_pet_10m', 'last_prod_pet', 'n_readings']
-            model = mlflow.sklearn.load_model("models:/oil_gas_prod_pet@production")
+            - Para fechas históricas con datos reales usa los features del offline store (parquet).
 
-        # Generamos el rango de fechas (primer día de cada mes)
-        dates = pd.date_range(start = date_start, end = date_end, freq = 'MS')
-        if len(dates) == 0:
-            raise HTTPException(status_code = 400, detail = "date_start debe ser anterior a date_end")
+            - Para fechas futuras o la fila futura del parquet (target nulo) usa el online store.
 
-        # Cargamos el parquet filtrado por el pozo e indexado por fecha
-        df = pd.read_parquet(PARQUET_PATH)
-        df['fecha'] = pd.to_datetime(df['fecha'])
-        well_df = df[df['idpozo'] == int(id_well)].set_index('fecha') # Filtramos pozo e index de fecha
+        No se hace actualización autoregresiva para evitar distribution shift en avg_prod_10m.
+        """
+        try:
+            if target not in ("gas", "pet"):
+                raise HTTPException(status_code = 400, detail = "target debe ser 'gas' o 'pet'")
 
-        if well_df.empty:
-            raise HTTPException(status_code = 404, detail = f"No se encontraron datos para el pozo {id_well}")
-        
-        min_date = well_df.index.min()
-        max_date = well_df.index.max()
+            # Definimos la columna target y seleccionamos modelo y features según el fluido a predecir
+            target_col = 'prod_gas' if target == 'gas' else 'prod_pet'
 
-        # Validación temporal: no permitir fechas anteriores al histórico
-        if any(date < min_date for date in dates):
-            raise HTTPException(
-                status_code = 400,
-                detail = f"No se permiten predicciones anteriores al histórico disponible ({min_date.date()} - período de entrenamiento)"
-            )
-
-        # Se inicializa lazy: el online store solo se consulta si hay fechas futuras en el rango
-        online_X = None
-
-        results = [] # Por cada mes del rango hacemos results.append(...) con la fecha y la predicción
-
-        for date in dates: # Iteramos todos los meses del input
-
-            # Es histórica solo si está en el parquet Y el target no es nulo
-            is_historical = (
-                date in well_df.index and
-                pd.notna(well_df.loc[date, target_col]) # La fila futura que agrega el DAG tiene target = None — se trata como futura
-            )
-
-            if is_historical:
-                # Usamos los features reales de esa fecha del offline store
-                X = well_df.loc[[date], feature_cols] # avg_prod_10m en T = promedio de T-10 a T-1 (shift(1) — sin leakage)
+            if target == "gas": # Cada target usa sus propios features de ventana porque gas y petróleo no siempre están correlacionados en pozos no convencionales
+                feature_cols = ['tipoextraccion', 'tef', 'profundidad', 'prod_agua',
+                                'avg_prod_gas_10m', 'last_prod_gas', 'n_readings']
+                model = self.model_gas
             else:
-                # Usamos el online store: una fila por pozo con el estado más reciente
-                # Se reutiliza para todos los meses futuros del rango (lazy load)
-                if online_X is None:
-                    store = FeatureStore(repo_path = FEATURE_STORE_REPO)
-                    online_features = store.get_online_features(
-                        features=[
-                            'well_stats:tipoextraccion',
-                            'well_stats:avg_prod_gas_10m',
-                            'well_stats:avg_prod_pet_10m',
-                            'well_stats:last_prod_gas',
-                            'well_stats:last_prod_pet',
-                            'well_stats:n_readings',
-                            'well_stats:profundidad',
-                            'well_stats:tef',
-                            'well_stats:prod_agua',
-                        ],
-                        entity_rows = [{"idpozo": int(id_well)}]
-                    ).to_df()
+                feature_cols = ['tipoextraccion', 'tef', 'profundidad', 'prod_agua',
+                                'avg_prod_pet_10m', 'last_prod_pet', 'n_readings']
+                model = self.model_pet
 
-                    if online_features.isnull().all(axis = 1).any():
-                        raise HTTPException(status_code = 404, detail = f"No se encontraron features para el pozo {id_well}")
+            # Generamos el rango de fechas (primer día de cada mes)
+            dates = pd.date_range(start = date_start, end = date_end, freq = 'MS')
+            if len(dates) == 0:
+                raise HTTPException(status_code = 400, detail = "date_start debe ser anterior a date_end")
 
-                    online_X = online_features[feature_cols]
+            # Cargamos el parquet filtrado por el pozo e indexado por fecha
+            df = pd.read_parquet(PARQUET_PATH)
+            df['fecha'] = pd.to_datetime(df['fecha'])
+            well_df = df[df['idpozo'] == int(id_well)].set_index('fecha') # Filtramos pozo e index de fecha
 
-                X = online_X
+            if well_df.empty:
+                raise HTTPException(status_code = 404, detail = f"No se encontraron datos para el pozo {id_well}")
 
-            # La producción no puede ser negativa, aplicamos floor en 0
-            pred = max(0.0, float(model.predict(X)[0]))
-            results.append({"date": date.strftime("%Y-%m-%d"), "prod": round(pred, 2)})
+            min_date = well_df.index.min()
+            max_date = well_df.index.max()
 
-        return {
-            "id_well": id_well,
-            "data": results
-        }
+            # Validación temporal: no permitir fechas anteriores al histórico
+            if any(date < min_date for date in dates):
+                raise HTTPException(
+                    status_code = 400,
+                    detail = f"No se permiten predicciones anteriores al histórico disponible ({min_date.date()} - período de entrenamiento)"
+                )
 
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code = 500, detail = str(e))
+            # Se inicializa lazy: el online store solo se consulta si hay fechas futuras en el rango
+            online_X = None
+
+            results = [] # Por cada mes del rango hacemos results.append(...) con la fecha y la predicción
+
+            for date in dates: # Iteramos todos los meses del input
+
+                # Es histórica solo si está en el parquet Y el target no es nulo
+                is_historical = (
+                    date in well_df.index and
+                    pd.notna(well_df.loc[date, target_col]) # La fila futura que agrega el DAG tiene target = None — se trata como futura
+                )
+
+                if is_historical:
+                    # Usamos los features reales de esa fecha del offline store
+                    X = well_df.loc[[date], feature_cols] # avg_prod_10m en T = promedio de T-10 a T-1 (shift(1) — sin leakage)
+                else:
+                    # Usamos el online store: una fila por pozo con el estado más reciente
+                    # Se reutiliza para todos los meses futuros del rango (lazy load)
+                    if online_X is None:
+                        online_features = self.store.get_online_features(
+                            features=[
+                                'well_stats:tipoextraccion',
+                                'well_stats:avg_prod_gas_10m',
+                                'well_stats:avg_prod_pet_10m',
+                                'well_stats:last_prod_gas',
+                                'well_stats:last_prod_pet',
+                                'well_stats:n_readings',
+                                'well_stats:profundidad',
+                                'well_stats:tef',
+                                'well_stats:prod_agua',
+                            ],
+                            entity_rows = [{"idpozo": int(id_well)}]
+                        ).to_df()
+
+                        if online_features.isnull().all(axis = 1).any():
+                            raise HTTPException(status_code = 404, detail = f"No se encontraron features para el pozo {id_well}")
+
+                        online_X = online_features[feature_cols]
+
+                    X = online_X
+
+                # La producción no puede ser negativa, aplicamos floor en 0
+                pred = max(0.0, float(model.predict(X)[0]))
+                results.append({"date": date.strftime("%Y-%m-%d"), "prod": round(pred, 2)})
+
+            return {
+                "id_well": id_well,
+                "data": results
+            }
+
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(status_code = 500, detail = str(e))
+
+
+# Entry point para `serve run api.main:app_deployment`
+app_deployment = APIDeployment.bind()

--- a/api/main.py
+++ b/api/main.py
@@ -4,6 +4,7 @@ from ray import serve
 import mlflow.sklearn
 import pandas as pd
 import os
+import ray
 import time
 
 # -------------------- CONFIGURACIÓN --------------------
@@ -184,6 +185,9 @@ app_deployment = APIDeployment.bind()
 # Entry point alternativo para `python -m api.main` (usado desde docker-compose).
 # Evita la dependencia en los flags del CLI `serve run`, que cambian entre versiones.
 if __name__ == "__main__":
+    # Inicializamos Ray explícitamente con el dashboard habilitado en el puerto 8265.
+    # Si no se hace antes de serve.start(), el dashboard queda deshabilitado por default.
+    ray.init(dashboard_host = "0.0.0.0", dashboard_port = 8265, include_dashboard = True)
     serve.start(http_options = {"host": "0.0.0.0", "port": 8000})
     serve.run(app_deployment)
     try:

--- a/api/main.py
+++ b/api/main.py
@@ -4,6 +4,7 @@ from ray import serve
 import mlflow.sklearn
 import pandas as pd
 import os
+import time
 
 # -------------------- CONFIGURACIÓN --------------------
 
@@ -178,3 +179,15 @@ class APIDeployment:
 
 # Entry point para `serve run api.main:app_deployment`
 app_deployment = APIDeployment.bind()
+
+
+# Entry point alternativo para `python -m api.main` (usado desde docker-compose).
+# Evita la dependencia en los flags del CLI `serve run`, que cambian entre versiones.
+if __name__ == "__main__":
+    serve.start(http_options = {"host": "0.0.0.0", "port": 8000})
+    serve.run(app_deployment)
+    try:
+        while True:
+            time.sleep(3600)
+    except KeyboardInterrupt:
+        serve.shutdown()

--- a/api/main.py
+++ b/api/main.py
@@ -4,7 +4,6 @@ from ray import serve
 import mlflow.sklearn
 import pandas as pd
 import os
-import ray
 import time
 
 # -------------------- CONFIGURACIÓN --------------------
@@ -185,9 +184,6 @@ app_deployment = APIDeployment.bind()
 # Entry point alternativo para `python -m api.main` (usado desde docker-compose).
 # Evita la dependencia en los flags del CLI `serve run`, que cambian entre versiones.
 if __name__ == "__main__":
-    # Inicializamos Ray explícitamente con el dashboard habilitado en el puerto 8265.
-    # Si no se hace antes de serve.start(), el dashboard queda deshabilitado por default.
-    ray.init(dashboard_host = "0.0.0.0", dashboard_port = 8265, include_dashboard = True)
     serve.start(http_options = {"host": "0.0.0.0", "port": 8000})
     serve.run(app_deployment)
     try:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -95,10 +95,9 @@ services:
 
   api:
     image: python:3.11-slim
-    command: bash -c "pip install fastapi feast==0.47.0 pandas mlflow scikit-learn pyarrow 'ray[serve,default]' && python -m api.main"
+    command: bash -c "pip install fastapi feast==0.47.0 pandas mlflow scikit-learn pyarrow 'ray[serve]' && python -m api.main"
     ports:
       - "8000:8000" # Swagger disponible en localhost:8000/docs
-      - "8265:8265" # Ray Dashboard (métricas de deployments y réplicas)
     volumes:
       - ./feature_store:/opt/airflow/feature_store
       - ./mlruns:/mlflow/mlruns

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -95,7 +95,7 @@ services:
 
   api:
     image: python:3.11-slim
-    command: bash -c "pip install fastapi feast==0.47.0 pandas mlflow scikit-learn pyarrow 'ray[serve]' && serve run api.main:app_deployment --host 0.0.0.0 --port 8000"
+    command: bash -c "pip install fastapi feast==0.47.0 pandas mlflow scikit-learn pyarrow 'ray[serve]' && serve run --http-host 0.0.0.0 --http-port 8000 api.main:app_deployment"
     ports:
       - "8000:8000" # Swagger disponible en localhost:8000/docs
       - "8265:8265" # Ray Dashboard (métricas de deployments y réplicas)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -95,7 +95,7 @@ services:
 
   api:
     image: python:3.11-slim
-    command: bash -c "pip install fastapi feast==0.47.0 pandas mlflow scikit-learn pyarrow 'ray[serve]' && serve run --http-host 0.0.0.0 --http-port 8000 api.main:app_deployment"
+    command: bash -c "pip install fastapi feast==0.47.0 pandas mlflow scikit-learn pyarrow 'ray[serve]' && python -m api.main"
     ports:
       - "8000:8000" # Swagger disponible en localhost:8000/docs
       - "8265:8265" # Ray Dashboard (métricas de deployments y réplicas)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -95,7 +95,7 @@ services:
 
   api:
     image: python:3.11-slim
-    command: bash -c "pip install fastapi feast==0.47.0 pandas mlflow scikit-learn pyarrow 'ray[serve]' && python -m api.main"
+    command: bash -c "pip install fastapi feast==0.47.0 pandas mlflow scikit-learn pyarrow 'ray[serve,default]' && python -m api.main"
     ports:
       - "8000:8000" # Swagger disponible en localhost:8000/docs
       - "8265:8265" # Ray Dashboard (métricas de deployments y réplicas)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -95,9 +95,10 @@ services:
 
   api:
     image: python:3.11-slim
-    command: bash -c "pip install fastapi uvicorn feast==0.47.0 pandas mlflow scikit-learn pyarrow && uvicorn api.main:app --host 0.0.0.0 --port 8000 --reload"
+    command: bash -c "pip install fastapi feast==0.47.0 pandas mlflow scikit-learn pyarrow 'ray[serve]' && serve run api.main:app_deployment --host 0.0.0.0 --port 8000"
     ports:
       - "8000:8000" # Swagger disponible en localhost:8000/docs
+      - "8265:8265" # Ray Dashboard (métricas de deployments y réplicas)
     volumes:
       - ./feature_store:/opt/airflow/feature_store
       - ./mlruns:/mlflow/mlruns


### PR DESCRIPTION
Cierra [#6](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/6).

## Resumen

Reemplaza el `uvicorn` de un solo proceso por un deployment de **Ray Serve** envolviendo la `app` de FastAPI existente. Los dos modelos (gas y pet) se cargan **una sola vez por réplica** en el `__init__` del deployment en lugar de recargarse desde MLFlow en cada request. La API pública (endpoints, query params, Swagger en `/docs`) no cambia.

## Cambios

**[docker-compose.yaml](docker-compose.yaml)** — servicio `api`:
- Suma `ray[serve]` al `pip install`.
- Command pasa de `uvicorn api.main:app` a `serve run api.main:app_deployment`.
- Expone el puerto `8265` para el Ray Dashboard.

**[api/main.py](api/main.py)** — refactor a deployment:
- Nueva clase `APIDeployment` decorada con `@serve.deployment(num_replicas=2, max_queued_requests=30)` + `@serve.ingress(app)`.
- Modelos `oil_gas_prod_gas@production` y `oil_gas_prod_pet@production` cargados en `__init__`.
- Cliente `FeatureStore` también inicializado una vez por réplica.
- Handlers `/api/v1/wells` y `/api/v1/forecast` pasan a ser métodos de la clase y consumen `self.model_gas`, `self.model_pet`, `self.store`.
- Se expone `app_deployment = APIDeployment.bind()` como entry point de `serve run`.

**[api/load_test.py](api/load_test.py)** — nuevo script de benchmarking del endpoint `/forecast`.

**[README.md](README.md)** — nueva Decisión de diseño 10 ("Arquitectura de serving") documentando: elección de Ray Serve + FastAPI, justificación del deployment unificado (análisis de memoria vs. overhead por réplica), configuración inicial, SLA objetivo y trade-offs pendientes de evaluar con datos reales. Se agrega Ray Dashboard al listado de servicios.

## Diferencias del `load_test.py` respecto al script de la práctica de la clase

El script está inspirado en el de la práctica de Serving (caso CyberMonday en MELI) y preserva su estructura (`RATE`, `TEST_DURATION_S`, `aiohttp` async, formato idéntico de output con `p50`/`p95`/`p99`, separación de latencia sobre 200s y error rate sobre 5xx). Las diferencias son:

**Adaptaciones forzadas por el diseño del endpoint:**
1. `GET` con query params en lugar de `POST` con body JSON (`/api/v1/forecast` es GET).
2. El payload toma `id_well` y `target` aleatorios del parquet del feature store en vez de generar features sintéticas con `random.uniform`/`randint`. Así cada request ejerce inferencia real contra los modelos y, en el caso de fechas futuras, contra el online store.

**Mejoras agregadas sobre el patrón base:**
3. Configuración vía variables de entorno (`RATE`, `TEST_DURATION_S`, `URL`, `DATE_START`, `DATE_END`, `PARQUET_PATH`). Permite correr los tres escenarios del test plan (50/5s, 140/5s, 140/30s) sin editar el archivo.
4. `random.seed(204)` al inicio. Dos corridas con la misma configuración y el mismo parquet eligen exactamente los mismos pozos y targets por request, así las métricas son directamente comparables entre corridas; la variabilidad restante viene del sistema, no del test.
5. Validación temprana del rango de fechas contra el parquet. Si `[DATE_START, DATE_END]` no tiene data en el parquet actual, el script aborta antes de disparar requests explicando qué rango sí está disponible. Evita reportes vacíos por 404 masivo cuando el DAG se ejecutó con otro rango.

## Decisión clave: deployment unificado con ambos modelos (vs. dos deployments separados)

Se optó por un único `APIDeployment` con ambos modelos cargados en memoria, y no por dos deployments independientes (uno gas, uno pet). Razones documentadas en la Decisión de diseño 10 del README:

- **Eficiencia de memoria.** Overhead de Ray Serve por réplica (~100 MB) > tamaño de cada modelo (~20-50 MB). Con unificado + 2 réplicas: 2 workers. Con separado 2×2: 4 workers → más memoria sin beneficio. Relevante en un host con 9 contenedores compartiendo RAM.
- **No hay evidencia empírica de asimetría de carga gas/pet.** El proyecto no tiene prediction log persistente todavía ([#15](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/15)). La distribución del dataset sugiere más pozos gasíferos, pero es proxy del dominio, no del tráfico real. Separar sin datos sería especulativo.
- **Simplicidad operativa.** Un único ciclo de vida, una única config, un único lugar donde ver logs y métricas.

Cuando haya métricas reales de uso y muestren asimetría sostenida (≥3× tráfico en un target, o latencia degradada en uno con capacidad ociosa en el otro), se separa. El issue [#26](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/26) define el criterio y el plan de separación.

Otros próximos pasos identificados y abiertos como issues:

- [#27](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/27) — Cache de inferencia con Redis para requests frecuentes.
- [#28](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/28) — Autoscaling dinámico del deployment con `autoscaling_config`.

## Test plan

Levantar el stack (`docker compose up -d`) y esperar ~2-3 minutos a que la API instale `ray[serve]` y los modelos se promuevan a alias `production` vía DAG.

- [ ] Verificar que `http://localhost:8000/docs` sirve Swagger con los endpoints `/api/v1/wells` y `/api/v1/forecast` sin cambios de contrato.
- [ ] Verificar que `http://localhost:8265` sirve el Ray Dashboard y muestra `APIDeployment` con 2 réplicas en estado `HEALTHY`.
- [ ] Hacer `curl` a `/api/v1/forecast?id_well=<algún pozo>&date_start=2019-07-01&date_end=2019-09-01&target=gas` — debería responder 200 con predicciones.
- [ ] Revisar logs del container `api`: el `load_model` de MLFlow debe aparecer exactamente 2 veces (una por réplica), no en cada request.
- [ ] Correr los 3 escenarios del load test y posterar resultados como comentario al PR:
  - `RATE=50 TEST_DURATION_S=5 python api/load_test.py` → baseline normal.
  - `RATE=140 TEST_DURATION_S=5 python api/load_test.py` → pico.
  - `RATE=140 TEST_DURATION_S=30 python api/load_test.py` → pico sostenido.

## Nota sobre numeración de decisiones

Este PR agrega la Decisión de diseño como "10" asumiendo que es la siguiente disponible en `main`. Si [#25](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/pull/25) (también "Decisión 10" — filtro COVID) se mergea antes, habrá que renumerar una de las dos en el rebase.