### PR TITLE
chore: agregar CODEOWNERS para auto-asignar reviewers en PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @clarikearney @fedehofmann


### PR DESCRIPTION
## Resumen

- Agrega `.github/CODEOWNERS` con `@clarikearney` y `@fedehofmann` como owners de todo el repo.
- A partir del merge, cualquier PR pide review automáticamente al owner que **no es** el autor: PRs míos piden review a Fede, PRs de Fede piden review a mí.

## Test plan

- [x] Después de mergear, abrir un PR de prueba y verificar que el reviewer queda asignado solo.