### PR TITLE
feat: migrar a XGBoost con incremental learning por chunks mensuales (cierra #36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,49 @@ Esto permite seguir la evolución del modelo a lo largo de los runs mensuales di
 - **Snapshot del dataset del run anterior como `reference` de Evidently** (en lugar de train). Sería una comparación más fiel al concepto de drift en producción, pero requiere persistir el parquet de cada run.
 - **Score compuesto** (R² + RMSE + bias) en `select_best_model` para que la promoción a producción sea más robusta que solo R². El roadmap de la entrega lo describe; queda como issue separada.
 
+### 13. Migración a XGBoost con incremental learning por chunks mensuales
+
+El proyecto usaba `RandomForestRegressor`, que carga el dataset completo en RAM al hacer `fit()`. Esa limitación no es de implementación: **es estructural al algoritmo**. Random Forest es un *bagging ensemble* donde cada árbol se entrena sobre un bootstrap sample del dataset completo, por lo que necesita acceso simultáneo a todo. No tiene `partial_fit` y no puede tenerlo. Con eso, entrenar localmente con histórico extenso (~2019 en adelante) era inviable: rompía por OOM.
+
+**Por qué XGBoost.** Es un *gradient boosting ensemble* construido secuencialmente: cada árbol nuevo aprende del error residual del modelo anterior. Esa propiedad permite hacer *continuation*: cargar un modelo previo y agregarle árboles entrenando solo con un chunk nuevo, sin tocar los anteriores. La memoria queda acotada por el tamaño del chunk, no por el dataset total.
+
+| Esquema | Memoria peak | Limitante |
+|---|---|---|
+| RandomForest + dataset completo (anterior) | `sizeof(dataset) + sizeof(modelo)` | Si el dataset > RAM → OOM, sin escape posible. |
+| XGBoost incremental por chunks (actual) | `sizeof(chunk) + sizeof(booster_creciente)` | Acotada por `chunk_size`, independiente del dataset total. |
+
+**Aclaración importante:** la mejora de memoria viene de **dos cambios juntos**: (1) cambiar el algoritmo a uno que soporte continuación, y (2) cambiar el bucle de entrenamiento de "un fit con todo" a "N fits, uno por chunk". XGBoost con `xgb.fit(dataset_completo)` reproduce el mismo OOM que RandomForest. Es la combinación lo que reduce memoria.
+
+**Implementación.** En `train_model`:
+
+1. El dataset de train (que ya viene con `event_timestamp` desde `split_data`) se agrupa por mes en orden cronológico.
+2. Para cada chunk mensual, se hace `XGBRegressor(...).fit(X_chunk, y_chunk, xgb_model=booster_path)`.
+3. El booster se guarda en formato `.ubj` (nativo de XGBoost) en disco después de cada chunk; ese path se pasa al chunk siguiente.
+4. Al final, el booster final tiene `n_estimators_per_chunk × n_chunks` árboles totales y se loguea en MLFlow vía `mlflow.xgboost.log_model(model_format="ubj")`.
+
+El orden cronológico es deliberado: los meses recientes pesan más en el modelo final, lo cual es coherente con el caso de uso de inferencia (predecir el mes siguiente).
+
+**Por qué XGBoost sobre SGDRegressor.** SGDRegressor también soporta `partial_fit` y mantiene memoria estrictamente constante, pero es **lineal** — pierde la capacidad de capturar relaciones no-lineales entre features de ventana (`avg_prod_gas_10m`, `last_prod_gas`) y features estáticas (`profundidad`, `tipoextraccion`). Esa pérdida sería significativa en producción de hidrocarburos donde las relaciones no son lineales.
+
+**Hiperparámetros que cambiaron respecto a RandomForest:**
+
+| RandomForest (anterior) | XGBoost (actual) | Notas |
+|---|---|---|
+| `n_estimators=100` (total de árboles del modelo final) | `n_estimators_per_chunk=10` (árboles a agregar por mes) | Pitfall: en continuation, `n_estimators` es árboles a agregar, **no total**. Con dataset de ~10 meses de train, llegamos a ~100 árboles totales. |
+| `max_depth=10` o `None` | `max_depth=6` (default XGB) | XGBoost tiende a generalizar mejor con árboles más conservadores. |
+| (no aplica) | `learning_rate=0.1` | RF no tiene equivalente. Default de XGB es 0.3 — agresivo para incremental. 0.1 es más estable: ningún chunk individual domina. |
+
+**Trade-offs aceptados:**
+
+- El booster crece con cada chunk (más árboles), pero el crecimiento es chico en términos absolutos — con `max_depth=6` y 100 árboles, el booster pesa < 10 MB.
+- `tipoextraccion` se sigue encodando con `LabelEncoder` (entero ordinal). XGBoost lo trata como ordinal numérico — subóptimo pero funciona. Migrar a `enable_categorical=True` con `pd.Categorical` queda para [issue #13](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/13).
+- La API de inferencia (`api/main.py`) carga ahora con `mlflow.xgboost.load_model` en lugar de `mlflow.sklearn.load_model` — cambio chico, transparente al cliente.
+
+**Lo que NO resuelve este cambio:**
+
+- El OOM en `prepare_offline_store` (carga del CSV completo + `groupby` + `rolling` con pandas in-memory). Eso es un cuello de botella separado, antes del training. Issue futura: refactorear ese task a procesamiento por chunks o usar Dask/Polars.
+- El OOM por presión total de containers (Ray Serve + entrenamiento + Evidently corriendo simultáneamente). Se mitiga parando `api-1` durante el DAG run o subiendo la RAM asignada a Docker Desktop.
+
 ---
 
 ## Feature Store

--- a/README.md
+++ b/README.md
@@ -633,9 +633,35 @@ El orden cronológico es deliberado: los meses recientes pesan más en el modelo
 - `tipoextraccion` se sigue encodando con `LabelEncoder` (entero ordinal). XGBoost lo trata como ordinal numérico — subóptimo pero funciona. Migrar a `enable_categorical=True` con `pd.Categorical` queda para [issue #13](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/13).
 - La API de inferencia (`api/main.py`) carga ahora con `mlflow.xgboost.load_model` en lugar de `mlflow.sklearn.load_model` — cambio chico, transparente al cliente.
 
+**Validación cuantitativa con tres escenarios de rango temporal:**
+
+Para cuantificar el tradeoff vs RandomForest se corrió el DAG con tres rangos crecientes (A: 2 años, B: 3 años, C: 4 años efectivos) en ambos modelos, midiendo tiempo, RAM peak, R², RMSE y MAE.
+
+**Resumen ejecutivo (escenario A, único comparable):**
+
+| Modelo | Estado | Tiempo total | Tiempo `train_model` | RAM peak worker |
+|---|---|---|---|---|
+| **XGBoost incremental** | ✅ success | **244s** | **45s** | **2,99 GiB** |
+| RandomForest | ✅ success | 469s | 211s | 3,53 GiB |
+
+**Performance (escenario A):**
+
+| Modelo | R² gas | R² pet | RMSE gas (m³) | RMSE pet (m³) |
+|---|---|---|---|---|
+| XGBoost | 0,871 | 0,863 | 668,9 | 393,8 |
+| RandomForest | **0,923** | **0,902** | **517,4** | **334,4** |
+
+**Hallazgo principal:** en escenarios B y C (3-4 años) **ambos modelos fallan en `split_data`** — Feast cargando todo en memoria al hacer `get_historical_features`. El próximo cuello de botella se mueve del training al feature store. Lectura: XGBoost incremental cumplió su promesa de resolver el OOM del training, pero el siguiente bottleneck aparece antes en el pipeline.
+
+**Tuning fallido:** se intentó cerrar la brecha de performance vs RandomForest con configuraciones más agresivas (`max_depth=10`, `learning_rate=0,2`, más árboles). Todos los experimentos empeoraron — varios con R² negativo. La causa es overfitting estructural: con `max_depth` alto cada árbol es muy expresivo, y al acumular muchos chunks el modelo memoriza patrones locales de los meses finales (que coinciden con el test set por el split temporal). Conclusión: **la configuración elegida (`max_depth=6`, `learning_rate=0,1`, `est_pc=5`) está cerca del techo accesible con esta arquitectura**. La pérdida de ~5 pp en R² no es por subóptima configuración, es el costo intrínseco del incremental learning con árboles en este dataset.
+
+**Camino para cerrar la brecha de performance:**
+
+La pérdida vs RandomForest no se cierra tuneando — se cierra dándole **más datos** al modelo (entrenar con 3+ años) o **mejores features** (sumar el segundo dataset del RFC con metadata estructural por pozo). Ambas mejoras requieren resolver primero el bottleneck de Feast en `split_data`. Por eso la prioridad siguiente del proyecto pasa al feature store, no al modelo.
+
 **Lo que NO resuelve este cambio:**
 
-- El OOM en `prepare_offline_store` (carga del CSV completo + `groupby` + `rolling` con pandas in-memory). Eso es un cuello de botella separado, antes del training. Issue futura: refactorear ese task a procesamiento por chunks o usar Dask/Polars.
+- El OOM en `split_data` y `prepare_offline_store` (Feast + pandas in-memory cargando todo el dataset). Es el siguiente cuello de botella prioritario y desbloquea entrenar con histórico extenso + sumar el segundo dataset (#18). Issue separado para tomar después.
 - El OOM por presión total de containers (Ray Serve + entrenamiento + Evidently corriendo simultáneamente). Se mitiga parando `api-1` durante el DAG run o subiendo la RAM asignada a Docker Desktop.
 
 ---

--- a/README.md
+++ b/README.md
@@ -690,6 +690,44 @@ Ninguna se cumple acá. Todos los pozos activos vienen ya etiquetados en el data
 
 Una conexión genuina con el espíritu de la clase es **cuantificar la incertidumbre de las predicciones** para que el operador sepa cuán confiado está el modelo en cada respuesta. XGBoost soporta nativamente *quantile regression* (`objective="reg:quantileerror"`), lo que permitiría devolver `(q10, q50, q90)` en lugar de un punto. Es una mejora real de UX para el consumidor de la API y se conecta con la idea de "incertidumbre epistémica vs aleatoria" de la slide 71. Queda registrado como reflexión arquitectónica para una segunda iteración pero fuera del alcance de esta entrega.
 
+### 15. Streaming / Continual Learning sub-mensual no aplica a este caso de uso
+
+La Clase 8 cubre aprendizaje sobre streams de datos: ingesta continua vía Kafka / Pub-Sub, motores de procesamiento como Flink (sub-milisegundo) o Spark Streaming (segundos), continual learning con algoritmos single-pass (Hoeffding Trees, FTRL-Proximal, SGD incremental) y frameworks como Vowpal Wabbit o River ML. Este proyecto **no** implementa ninguno de esos componentes a esa cadencia, y la decisión es estructural sobre el dominio.
+
+#### Por qué no aplica streaming a sub-segundo / sub-milisegundo
+
+Streaming asume tres condiciones que justifican el costo de la infraestructura asociada:
+
+1. **Ingesta continua de eventos**: clicks, transacciones, mensajes, sensores. Decenas o miles de eventos por segundo.
+2. **Costo de oportunidad por latencia**: la decisión de negocio pierde valor si tarda segundos (ads/recomendaciones, fraude, dynamic pricing — slide 7 de la clase).
+3. **Cadencia rápida del mundo real**: el fenómeno modelado cambia a la velocidad de los eventos.
+
+Ninguna se cumple acá:
+
+1. **Los datos vienen mensualmente** del Ministerio de Energía como dataset estructurado del régimen regulatorio. No hay un stream de eventos por segundo — hay 12 actualizaciones del dataset por año.
+2. **El consumidor de la API es un analista de producción o un dashboard de planificación**, no un loop de control que decide en milisegundos. La latencia tolerable es de segundos (ver SLA en Decisión #10), no de microsegundos.
+3. **La producción de un pozo cambia a escala de meses**, no de segundos. Un decline rate típico se mide en porcentaje mensual, y las decisiones operativas (workover, intervención, abandono) se toman en horizontes de semanas a meses.
+
+#### Por qué tampoco aplica continual learning sub-mensual
+
+Continual learning *sub-mensual* (actualizar el modelo cada hora / día / minuto a partir de eventos individuales) tiene los mismos prerrequisitos que streaming, más uno propio: **la dinámica del fenómeno tiene que cambiar lo suficientemente rápido como para que valga la pena reentrenar entre ciclos batch**. En oil & gas no es así: los reportes regulatorios son mensuales, las features de ventana (`avg_prod_*_10m`) usan ventanas de 10 meses, el target es producción mensual. Reentrenar más seguido no agrega información — los datos no llegan más rápido que el ciclo del DAG.
+
+#### Lo que sí está implementado del concepto: continual learning a cadencia mensual
+
+Conviene aclarar que **el proyecto sí implementa continual learning, pero a la cadencia natural del dominio (mensual)**, no en streaming. La Decisión #13 (XGBoost incremental por chunks mensuales) implementa exactamente la idea de "actualizar el modelo con cada chunk nuevo de datos sin recargar el histórico completo en memoria" — el chunk es un mes en lugar de un evento. Esa decisión cubre el principio de la clase 8 (memoria acotada, single-pass por chunk) ajustado a la cadencia del problema.
+
+#### Trade-offs frente a streaming real
+
+| Aspecto | Streaming real (no implementado) | Mensual con XGBoost incremental (elegido) |
+|---|---|---|
+| Latencia de actualización del modelo | Segundos a minutos | Un mes (cuando corre el DAG) |
+| Frescura de features | Sub-segundo (Redis + OLAP) | Mensual (Feast online store, SQLite) |
+| Infra requerida | Kafka + Flink + Redis + OLAP DB + cluster 24/7 | Airflow + MLflow + Feast + Ray Serve |
+| Costo operativo (OpEx) | Alto sostenido (slide 49 de la clase) | Bajo, escala con triggers del DAG |
+| Justificación de negocio | Necesaria si la latencia importa para la decisión | No necesaria — el horizonte es mensual |
+
+La slide 50 de la clase plantea exactamente este trade-off: "si un modelo XGBoost estático alcanza 86 % y la variante en streaming logra 88 %, el impacto de negocio de ese +2 % debe justificar el aumento de infraestructura". En este caso, ese +2 % no compensa el orden de magnitud de complejidad operativa que sumaría streaming. La conclusión coincide con la slide 51 de la clase: continual learning aplica para "motores publicitarios, pricing dinámico, mercados financieros, ciberseguridad" — no para predicción de producción regulatoria con cadencia mensual.
+
 ---
 
 ## Feature Store

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ El DAG excluye automáticamente el año 2020 del entrenamiento (param `exclude_y
 
 ### Modelo y métricas
 
-Se entrenan dos modelos independientes (`prod_gas` y `prod_pet`) usando **RandomForestRegressor**. Se evalúan 10 experimentos en total (5 por target) variando `n_estimators`, `max_depth` y el conjunto de features. El modelo con mejor R² es promovido automáticamente a producción en MLFlow.
+Se entrenan dos modelos independientes (`prod_gas` y `prod_pet`) usando **XGBoost con incremental learning por chunks mensuales**. Se evalúan 10 experimentos en total (5 por target) variando `n_estimators_per_chunk`, `max_depth` y el conjunto de features. El modelo con mejor R² es promovido automáticamente a producción en MLFlow. La elección de XGBoost sobre RandomForest está motivada por la necesidad de mantener el uso de RAM acotado al tamaño del chunk en lugar del dataset completo — ver [Decisión #13](#13-migración-a-xgboost-con-incremental-learning-por-chunks-mensuales).
 
 Las métricas de evaluación son **R²**, **RMSE** y **MAE** sobre un test set temporal (20% de fechas más recientes).
 
@@ -663,6 +663,32 @@ La pérdida vs RandomForest no se cierra tuneando — se cierra dándole **más 
 
 - El OOM en `split_data` y `prepare_offline_store` (Feast + pandas in-memory cargando todo el dataset). Es el siguiente cuello de botella prioritario y desbloquea entrenar con histórico extenso + sumar el segundo dataset (#18). Issue separado para tomar después.
 - El OOM por presión total de containers (Ray Serve + entrenamiento + Evidently corriendo simultáneamente). Se mitiga parando `api-1` durante el DAG run o subiendo la RAM asignada a Docker Desktop.
+
+### 14. Human-in-the-Loop y Active Learning no aplican a este caso de uso
+
+La Clase 7 de la materia cubre Human-in-the-Loop (HITL) y Active Learning como pilares de MLOps en muchos casos reales. Este proyecto **no implementa** ninguno de los dos, y la decisión es estructural sobre la naturaleza del problema, no una omisión.
+
+#### Por qué no aplica HITL
+
+HITL asume que la **anotación humana** es parte del pipeline: hay datos sin label, humanos los etiquetan, y esas etiquetas alimentan el reentrenamiento. Es el patrón estándar en clasificación de imágenes, NLP, detección de objetos, moderación de contenido, etc.
+
+Acá el ground truth es **medido instrumentalmente**: la producción mensual de cada pozo (en m³) se reporta a la Secretaría de Energía como dato regulatorio, derivado de medidores físicos en boca de pozo y sistemas SCADA de las operadoras. No hay anotador, no hay subjetividad, no hay desacuerdo posible entre etiquetadores. El label es lo que el medidor registró.
+
+Como consecuencia, no aplican: anotadores in-house vs BPO vs crowdsourcing, Krippendorff's alpha / acuerdo entre anotadores, golden tasks para auditar trabajadores, agregación de votos por mayoría, ni el diseño de UI de anotación.
+
+#### Por qué no aplica Active Learning
+
+Active Learning sirve para **decidir qué muestras sin etiquetar mandar a anotación primero**, optimizando el retorno por hora de anotador. Tres precondiciones:
+
+1. Hay un pool grande de datos sin etiqueta.
+2. Etiquetarlos cuesta (humano + tiempo).
+3. Se puede medir la incertidumbre del modelo sobre ellos para priorizar.
+
+Ninguna se cumple acá. Todos los pozos activos vienen ya etiquetados en el dataset oficial cada mes. No hay un pool de pozos "sin label" esperando que alguien decida cuáles entrenar primero. Las técnicas específicas (least confidence, margin sampling, entropy, query by committee, muestreo por diversidad / clusters / outliers) no tienen donde aplicarse.
+
+#### Lo que sí podría tener sentido en una iteración futura
+
+Una conexión genuina con el espíritu de la clase es **cuantificar la incertidumbre de las predicciones** para que el operador sepa cuán confiado está el modelo en cada respuesta. XGBoost soporta nativamente *quantile regression* (`objective="reg:quantileerror"`), lo que permitiría devolver `(q10, q50, q90)` en lugar de un punto. Es una mejora real de UX para el consumidor de la API y se conecta con la idea de "incertidumbre epistémica vs aleatoria" de la slide 71. Queda registrado como reflexión arquitectónica para una segunda iteración pero fuera del alcance de esta entrega.
 
 ---
 

--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, HTTPException
 from feast import FeatureStore
 from ray import serve
-import mlflow.sklearn
+import mlflow.xgboost
 import pandas as pd
 import os
 import time
@@ -36,9 +36,11 @@ class APIDeployment:
     """
 
     def __init__(self):
-        # Cargamos ambos modelos desde MLFlow una sola vez por réplica
-        self.model_gas = mlflow.sklearn.load_model("models:/oil_gas_prod_gas@production")
-        self.model_pet = mlflow.sklearn.load_model("models:/oil_gas_prod_pet@production")
+        # Cargamos ambos modelos XGBoost desde MLFlow una sola vez por réplica.
+        # El registro usa formato .ubj (nativo de XGBoost) — más portable entre versiones
+        # que pickle de RandomForest, que era el approach previo a #36.
+        self.model_gas = mlflow.xgboost.load_model("models:/oil_gas_prod_gas@production")
+        self.model_pet = mlflow.xgboost.load_model("models:/oil_gas_prod_pet@production")
 
         # Feature store client también reutilizable entre requests
         self.store = FeatureStore(repo_path = FEATURE_STORE_REPO)

--- a/dags/dag_oil_and_gas.py
+++ b/dags/dag_oil_and_gas.py
@@ -18,6 +18,12 @@ EXPERIMENTS = [
     # Total de árboles del modelo final = n_estimators_per_chunk * cantidad de meses en train.
     # Ej: con dataset de ~10 meses de train, n_estimators_per_chunk=10 → ~100 árboles totales.
     # learning_rate=0.1 (más conservador que el default 0.3, ningún chunk individual domina).
+    #
+    # Grilla validada experimentalmente: configuraciones más agresivas (max_depth=10,
+    # learning_rate=0.2) generan overfitting estructural por la combinación incremental
+    # + árboles profundos (cada chunk se ajusta al residuo local y memoriza patrones del
+    # mes; con muchos chunks se sobreajusta justo a los meses contiguos al test set).
+    # Detalle en la bitácora: "Tuning fallido — la config conservadora era el techo".
 
     # prod_pet: variando n_estimators_per_chunk
     {'target': 'prod_pet', 'model_params': {'n_estimators_per_chunk': 5,  'max_depth': 6, 'learning_rate': 0.1, 'random_state': 42}, 'features': ALL_FEATURES_PET},

--- a/dags/dag_oil_and_gas.py
+++ b/dags/dag_oil_and_gas.py
@@ -4,7 +4,6 @@ from airflow.models.param import Param
 from sklearn.preprocessing import LabelEncoder
 import pandas as pd # Lo usamos en varias tasks asi que tiene sentido importarlo fuera del dag
 import os # Lo usamos en varias tasks asi que tiene sentido importarlo fuera del dag
-import pickle # Lo usamos en varias tasks asi que tiene sentido importarlo fuera del dag
 
 # -------------------- EXPERIMENTOS --------------------
 
@@ -15,22 +14,28 @@ ALL_FEATURES_GAS = ['tipoextraccion', 'tef', 'profundidad', 'prod_agua', 'avg_pr
 REDUCED_FEATURES_GAS = ['tipoextraccion', 'tef', 'profundidad']
 
 EXPERIMENTS = [
-    # prod_pet: variando n_estimators
-    {'target': 'prod_pet', 'model_params': {'n_estimators': 50, 'random_state': 42}, 'features': ALL_FEATURES_PET},
-    {'target': 'prod_pet', 'model_params': {'n_estimators': 100, 'random_state': 42}, 'features': ALL_FEATURES_PET},
-    # prod_pet: limitando profundidad del árbol
-    {'target': 'prod_pet', 'model_params': {'n_estimators': 100, 'random_state': 42, 'max_depth': 5}, 'features': ALL_FEATURES_PET},
-    {'target': 'prod_pet', 'model_params': {'n_estimators': 100, 'random_state': 42, 'max_depth': 10}, 'features': ALL_FEATURES_PET},
-    # prod_pet: features reducidas
-    {'target': 'prod_pet', 'model_params': {'n_estimators': 100, 'random_state': 42}, 'features': REDUCED_FEATURES_PET},
-    # prod_gas: variando n_estimators
-    {'target': 'prod_gas', 'model_params': {'n_estimators': 50, 'random_state': 42}, 'features': ALL_FEATURES_GAS},
-    {'target': 'prod_gas', 'model_params': {'n_estimators': 100, 'random_state': 42}, 'features': ALL_FEATURES_GAS},
-    # prod_gas: limitando profundidad
-    {'target': 'prod_gas', 'model_params': {'n_estimators': 100, 'random_state': 42, 'max_depth': 5}, 'features': ALL_FEATURES_GAS},
-    {'target': 'prod_gas', 'model_params': {'n_estimators': 100, 'random_state': 42, 'max_depth': 10}, 'features': ALL_FEATURES_GAS},
+    # XGBoost incremental: n_estimators_per_chunk = árboles agregados por mes (chunk).
+    # Total de árboles del modelo final = n_estimators_per_chunk * cantidad de meses en train.
+    # Ej: con dataset de ~10 meses de train, n_estimators_per_chunk=10 → ~100 árboles totales.
+    # learning_rate=0.1 (más conservador que el default 0.3, ningún chunk individual domina).
+
+    # prod_pet: variando n_estimators_per_chunk
+    {'target': 'prod_pet', 'model_params': {'n_estimators_per_chunk': 5,  'max_depth': 6, 'learning_rate': 0.1, 'random_state': 42}, 'features': ALL_FEATURES_PET},
+    {'target': 'prod_pet', 'model_params': {'n_estimators_per_chunk': 10, 'max_depth': 6, 'learning_rate': 0.1, 'random_state': 42}, 'features': ALL_FEATURES_PET},
+    # prod_pet: variando max_depth
+    {'target': 'prod_pet', 'model_params': {'n_estimators_per_chunk': 10, 'max_depth': 4, 'learning_rate': 0.1, 'random_state': 42}, 'features': ALL_FEATURES_PET},
+    {'target': 'prod_pet', 'model_params': {'n_estimators_per_chunk': 10, 'max_depth': 8, 'learning_rate': 0.1, 'random_state': 42}, 'features': ALL_FEATURES_PET},
+    # prod_pet: features reducidas (baseline de ablación)
+    {'target': 'prod_pet', 'model_params': {'n_estimators_per_chunk': 10, 'max_depth': 6, 'learning_rate': 0.1, 'random_state': 42}, 'features': REDUCED_FEATURES_PET},
+
+    # prod_gas: variando n_estimators_per_chunk
+    {'target': 'prod_gas', 'model_params': {'n_estimators_per_chunk': 5,  'max_depth': 6, 'learning_rate': 0.1, 'random_state': 42}, 'features': ALL_FEATURES_GAS},
+    {'target': 'prod_gas', 'model_params': {'n_estimators_per_chunk': 10, 'max_depth': 6, 'learning_rate': 0.1, 'random_state': 42}, 'features': ALL_FEATURES_GAS},
+    # prod_gas: variando max_depth
+    {'target': 'prod_gas', 'model_params': {'n_estimators_per_chunk': 10, 'max_depth': 4, 'learning_rate': 0.1, 'random_state': 42}, 'features': ALL_FEATURES_GAS},
+    {'target': 'prod_gas', 'model_params': {'n_estimators_per_chunk': 10, 'max_depth': 8, 'learning_rate': 0.1, 'random_state': 42}, 'features': ALL_FEATURES_GAS},
     # prod_gas: features reducidas
-    {'target': 'prod_gas', 'model_params': {'n_estimators': 100, 'random_state': 42}, 'features': REDUCED_FEATURES_GAS},
+    {'target': 'prod_gas', 'model_params': {'n_estimators_per_chunk': 10, 'max_depth': 6, 'learning_rate': 0.1, 'random_state': 42}, 'features': REDUCED_FEATURES_GAS},
 ]
 
 # -------------------- DAG --------------------
@@ -255,8 +260,12 @@ def ml_pipeline():
     train_df = training_df[training_df['event_timestamp'] <  cutoff_date]
     test_df  = training_df[training_df['event_timestamp'] >= cutoff_date]
 
-    # X es igual para ambos targets: mismas filas, mismas columnas (sin ID, timestamp ni targets)
-    non_features = ['idpozo', 'event_timestamp', 'prod_pet', 'prod_gas']
+    # X es igual para ambos targets: mismas filas, mismas columnas.
+    # IMPORTANTE: mantenemos event_timestamp en X para que train_model pueda iterar por mes
+    # (chunks mensuales para incremental learning con XGBoost). En train_model y evaluate_model
+    # se filtra X a `[features]` antes de pasarlo al modelo, así que event_timestamp queda
+    # disponible para particionar el dataset pero nunca llega como feature al modelo.
+    non_features = ['idpozo', 'prod_pet', 'prod_gas']
     X_train = train_df.drop(columns = non_features)
     X_test  = test_df.drop(columns = non_features)
 
@@ -288,132 +297,186 @@ def ml_pipeline():
   @task
   def train_model(splits, config):
       """
-      Entrena un RandomForestRegressor según la configuración del experimento,
-      guarda el modelo en disco y retorna metadata para que evaluate_model lo evalúe.
+      Entrena un XGBRegressor en chunks mensuales (incremental learning) según la
+      configuración del experimento, guarda el booster final en disco y retorna metadata.
 
-      Args: splits (dict) - diccionario con paths a cada uno de los subconjuntos de train y test,
-            config (dict) - configuración del experimento con target, features y model_params.
-      Retorna: dict con metadata del modelo (target, features, ruta, n_samples, model_params).
+      A diferencia de RandomForest, donde cada `fit` requiere todo el dataset en RAM,
+      XGBoost permite continuar el entrenamiento sobre un modelo previo: cada chunk
+      agrega árboles nuevos al final del booster sin tocar los anteriores. Esto acota
+      el uso de memoria a `chunk_actual + booster_creciente` (~MB) en lugar de
+      `dataset_completo + modelo` (~GB con histórico extenso).
+
+      Iteración por mes en orden temporal: el split de Feast ya viene con
+      `event_timestamp`. Se agrupa por `(año, mes)` y se hace `XGBRegressor.fit`
+      sobre cada chunk pasando `xgb_model=booster_path` para continuar el modelo
+      previo. El orden temporal es deliberado: los meses recientes pesan más en el
+      modelo final, lo cual es coherente con el caso de uso de inferencia
+      (predecir el mes siguiente).
+
+      Args: splits (dict) - paths a los subconjuntos train/test (output de split_data).
+            config (dict) - configuración del experimento. `model_params` debe incluir
+            `n_estimators_per_chunk` (árboles a agregar por mes), `max_depth`,
+            `learning_rate`, `random_state`.
+      Retorna: dict con metadata del modelo (target, features, model_path, n_samples,
+            n_chunks, model_params con n_estimators_total calculado).
       """
-      from sklearn.ensemble import RandomForestRegressor
+      import xgboost as xgb
 
       # Extraemos la configuración del experimento
       target = config['target']
       features = config['features']
-      model_params = config['model_params']
+      base_params = config['model_params']
+      n_estimators_per_chunk = base_params['n_estimators_per_chunk']
 
-      # Construimos el path del modelo en base al target y los hiperparámetros
-      model_path = f'/opt/airflow/models/model_{target}_est{model_params["n_estimators"]}_depth{model_params.get("max_depth", "none")}.pkl'
+      # Convertimos a hiperparámetros aceptados por XGBRegressor
+      # (sacamos n_estimators_per_chunk y agregamos n_estimators con su valor)
+      xgb_params = {k: v for k, v in base_params.items() if k != 'n_estimators_per_chunk'}
+      xgb_params['n_estimators'] = n_estimators_per_chunk
 
-      # Leemos los subconjuntos de train filtrando solo las features del experimento
-      X_train = pd.read_parquet(splits.get(target).get('X_train'))[features]
-      y_train = pd.read_parquet(splits.get(target).get('y_train')).squeeze()
-
-      # Creamos el modelo con los hiperparámetros del experimento
-      # Random Forest construye N árboles de decisión, cada uno entrenado con una muestra aleatoria distinta de los datos y un subconjunto aleatorio de features
-      # Para predecir, promedia los resultados de todos los árboles
-      model = RandomForestRegressor(**model_params)
-
-      # Lo entrenamos
-      model.fit(X_train, y_train)
-
-      # Creamos la carpeta si no existe (pickle falla si la carpeta no existe)
+      # Path del modelo en formato .ubj (nativo de XGBoost — más portable que pickle entre versiones)
+      model_path = f'/opt/airflow/models/model_{target}_est{n_estimators_per_chunk}_depth{xgb_params.get("max_depth", "default")}_feat{"all" if len(features) > 3 else "reduced"}.ubj'
       os.makedirs(os.path.dirname(model_path), exist_ok = True)
 
-      # Guardamos el modelo en disco en formato binario
-      # Lo que guardamos es el objeto modelo completo: todos los árboles con sus reglas de split
-      with open(model_path, 'wb') as f:
-          pickle.dump(model, f)
+      # Leemos X_train completo (con event_timestamp) y y_train
+      X_train = pd.read_parquet(splits.get(target).get('X_train'))
+      y_train = pd.read_parquet(splits.get(target).get('y_train')).squeeze()
 
+      # Aseguramos que event_timestamp es datetime para poder agrupar por mes
+      X_train['event_timestamp'] = pd.to_datetime(X_train['event_timestamp'])
+
+      # Iteramos por mes en orden temporal (sort=True por default en groupby)
+      booster_path = None
+      n_chunks = 0
+      n_samples_total = 0
+
+      for periodo, X_chunk in X_train.groupby(X_train['event_timestamp'].dt.to_period('M')):
+          # Aislamos las features que el modelo usa (event_timestamp, idpozo, etc. no entran)
+          X_chunk_features = X_chunk[features]
+          y_chunk = y_train.loc[X_chunk.index]
+
+          # Creamos un nuevo XGBRegressor por chunk con los mismos hiperparámetros estructurales.
+          # Pasar xgb_model=booster_path le dice a XGBoost que continúe el modelo previo
+          # (sin xgb_model, .fit() reentrena desde cero silenciosamente — pitfall conocido).
+          model = xgb.XGBRegressor(**xgb_params)
+          if booster_path is not None:
+              model.fit(X_chunk_features, y_chunk, xgb_model = booster_path)
+          else:
+              model.fit(X_chunk_features, y_chunk)
+
+          # Guardamos el booster en formato nativo .ubj (sobreescribe la versión anterior)
+          model.save_model(model_path)
+          booster_path = model_path
+          n_chunks += 1
+          n_samples_total += len(X_chunk)
+
+      # Devolvemos metadata. n_estimators_total refleja la cantidad real de árboles
+      # del modelo final (cada chunk agregó n_estimators_per_chunk árboles).
       return {
           'target': target,
           'features': features,
           'model_path': model_path,
-          'n_samples': len(X_train),
-          'model_params': model_params
+          'n_samples': n_samples_total,
+          'n_chunks': n_chunks,
+          'model_params': {
+              **xgb_params,
+              'n_estimators_per_chunk': n_estimators_per_chunk,
+              'n_estimators_total': n_estimators_per_chunk * n_chunks,
+          }
       }
   
   @task
   def evaluate_model(results, splits):
     """
-    Carga el modelo entrenado, evalúa sus métricas sobre el conjunto de test,
-    las loguea en MLflow y registra el modelo con un nombre para poder cargarlo desde la API.
+    Carga el modelo XGBoost entrenado en chunks, evalúa sus métricas sobre el conjunto
+    de test, las loguea en MLflow y registra el modelo en el Model Registry para que
+    la API pueda cargarlo en inferencia.
 
-    Args: results (dict) - metadata del modelo incluyendo target, features y model_path,
-          splits (dict) - diccionario con paths a cada uno de los subconjuntos de train y test.
-    Retorna: None.
+    Args: results (dict) - metadata del modelo incluyendo target, features y model_path
+          (booster en formato .ubj generado por train_model).
+          splits (dict) - paths a los subconjuntos train/test.
+    Retorna: dict con target y run_id (consumido por select_best_model).
     """
-    # Importamos métricas de Sickit Learn
     from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
-
-    # Importamos MLFlow
+    import xgboost as xgb
     import mlflow
-    import mlflow.sklearn
+    import mlflow.xgboost
     from mlflow.tracking import MlflowClient
 
-    # Definimos las variables que fueron seleccionadas para entrenar (tienen que ser las mismas para no romper)
     features = results['features']
 
-    # Leemos los subconjuntos de train y test
+    # Leemos test set filtrado a las features del experimento (X_test puede traer
+    # event_timestamp por el cambio en split_data, así que lo filtramos explícitamente)
     X_test = pd.read_parquet(splits.get(results['target']).get('X_test'))[features]
     y_test = pd.read_parquet(splits.get(results['target']).get('y_test')).squeeze()
 
-    # Cargamos el modelo
-    loaded_model = pickle.load(open(results['model_path'], 'rb'))
+    # Cargamos el booster desde el path .ubj que generó train_model
+    loaded_model = xgb.XGBRegressor()
+    loaded_model.load_model(results['model_path'])
     y_pred = loaded_model.predict(X_test)
 
-    # Calculamos métricas en testing
+    # Métricas en testing
     mae = mean_absolute_error(y_test, y_pred)
     mse = mean_squared_error(y_test, y_pred)
     rmse = mse ** 0.5
     r2 = r2_score(y_test, y_pred)
 
     # Nombre descriptivo del run para identificarlo en la UI de MLflow
-    # Ej: "prod_gas_est100_depth5_featall"
-    run_name = f"{results['target']}_est{results['model_params']['n_estimators']}_depth{results['model_params'].get('max_depth', 'none')}_feat{'all' if len(results['features']) > 2 else 'reduced'}"
+    # Ej: "prod_gas_est10pc_depth6_featall" — pc = per chunk
+    n_estimators_pc = results['model_params']['n_estimators_per_chunk']
+    n_estimators_total = results['model_params']['n_estimators_total']
+    depth_label = str(results['model_params'].get('max_depth', 'default'))
+    feat_label = 'all' if len(results['features']) > 3 else 'reduced'
+    run_name = f"{results['target']}_est{n_estimators_pc}pc_depth{depth_label}_feat{feat_label}"
 
     # Seleccionamos el experimento donde se van a agrupar todos los runs
     mlflow.set_experiment('ml_pipeline_oil_and_gas')
 
-    with mlflow.start_run(run_name = run_name): # Abrimos un nuevo run con ese nombre
-        mlflow.log_param('target', results['target']) # Logueamos manualmente el target para filtrar en la UI
-        mlflow.log_params(results['model_params']) # Logueamos los hiperparámetros del experimento
-        mlflow.log_metric('mae', mae) # Métricas de evaluación
+    with mlflow.start_run(run_name = run_name):
+        mlflow.log_param('target', results['target'])
+        mlflow.log_param('n_chunks', results['n_chunks'])
+        mlflow.log_params(results['model_params'])  # incluye n_estimators_per_chunk y _total
+        mlflow.log_metric('mae', mae)
         mlflow.log_metric('mse', mse)
         mlflow.log_metric('rmse', rmse)
         mlflow.log_metric('r2', r2)
-        # Registramos el modelo con un nombre para poder cargarlo después desde la API
-        # Cada run crea una nueva versión del modelo registrado
-        mlflow.sklearn.log_model(loaded_model, "model", registered_model_name = f"oil_gas_{results['target']}")
+        # Registramos el modelo con formato .ubj nativo (más portable que pickle entre versiones).
+        # mlflow.xgboost guarda el booster en formato JSON/UBJ y preserva metadata específica
+        # de XGBoost (incluyendo soporte para enable_categorical=True si se migra a ese esquema).
+        mlflow.xgboost.log_model(
+            loaded_model,
+            name = "model",
+            model_format = "ubj",
+            registered_model_name = f"oil_gas_{results['target']}",
+        )
 
-        # Agregamos tags y descripción a la versión recién creada para que el Model Registry sea legible
+        # Tags y descripción en el Model Registry para que sea legible sin abrir cada run
         client = MlflowClient()
         run_id = mlflow.active_run().info.run_id
         versions = client.search_model_versions(f"run_id='{run_id}'")
         if versions:
             model_name = f"oil_gas_{results['target']}"
             version = versions[0].version
-            feat_label = 'all' if len(results['features']) > 3 else 'reduced'
-            depth_label = str(results['model_params'].get('max_depth', 'None'))
 
             client.set_model_version_tag(model_name, version, 'run_name', run_name)
-            client.set_model_version_tag(model_name, version, 'n_estimators', str(results['model_params']['n_estimators']))
+            client.set_model_version_tag(model_name, version, 'n_estimators_per_chunk', str(n_estimators_pc))
+            client.set_model_version_tag(model_name, version, 'n_estimators_total', str(n_estimators_total))
             client.set_model_version_tag(model_name, version, 'max_depth', depth_label)
+            client.set_model_version_tag(model_name, version, 'learning_rate', str(results['model_params'].get('learning_rate', 'default')))
             client.set_model_version_tag(model_name, version, 'features', feat_label)
             client.set_model_version_tag(model_name, version, 'r2', f"{r2:.4f}")
 
             client.update_model_version(
                 name = model_name,
                 version = version,
-                description = f"RandomForest | n_estimators={results['model_params']['n_estimators']} | max_depth={depth_label} | features={feat_label} | R²={r2:.4f} | RMSE={rmse:.2f}"
+                description = f"XGBoost incremental | {n_estimators_pc} árboles/chunk × {results['n_chunks']} chunks = {n_estimators_total} árboles | max_depth={depth_label} | features={feat_label} | R²={r2:.4f} | RMSE={rmse:.2f}"
             )
 
-            # Descripción a nivel del modelo registrado (se sobreescribe en cada run, pero el contenido es estático)
+            # Descripción a nivel del modelo registrado (estática)
             fluid = 'petróleo' if results['target'] == 'prod_pet' else 'gas'
             feat_list = ', '.join(results['features'])
             client.update_registered_model(
                 name = model_name,
-                description = f"Predice producción mensual de {fluid} (m³) por pozo. Entrenado con RandomForestRegressor sobre datos del MINEM (producción no convencional). Features: {feat_list}."
+                description = f"Predice producción mensual de {fluid} (m³) por pozo. Entrenado con XGBoost incremental por chunks mensuales sobre datos del MINEM (producción no convencional). Features: {feat_list}."
             )
 
         return {"target": results['target'], "run_id": run_id}
@@ -492,7 +555,7 @@ def ml_pipeline():
     """
     import logging
     import mlflow
-    import mlflow.sklearn
+    import mlflow.xgboost
     from mlflow.tracking import MlflowClient
     from evidently.report import Report
     from evidently.metric_preset import RegressionPreset, DataDriftPreset
@@ -514,9 +577,10 @@ def ml_pipeline():
     for target in ['prod_gas', 'prod_pet']:
         model_name = f"oil_gas_{target}"
 
-        # Cargamos el modelo promovido a producción y leemos sus features
-        # feature_names_in_ está disponible en sklearn 1.0+ y refleja las columnas usadas en fit
-        loaded_model = mlflow.sklearn.load_model(f"models:/{model_name}@production")
+        # Cargamos el modelo promovido a producción y leemos sus features.
+        # XGBRegressor (sklearn API) expone feature_names_in_ vía property que delega
+        # al booster — funciona igual que con sklearn estimators.
+        loaded_model = mlflow.xgboost.load_model(f"models:/{model_name}@production")
         features = list(loaded_model.feature_names_in_)
 
         # Leemos splits restringidos a las features del modelo

--- a/roadmap.md
+++ b/roadmap.md
@@ -12,7 +12,7 @@
 | ✅ Mergeado | #29 Ray Serve (cubre #6 obligatorio) | 2026-04-30 | `num_replicas=2` unificado |
 | ✅ Mergeado | #25 Filtro automático COVID | 2026-04-30 | Default `exclude_years=[2020]` |
 | 🔄 En curso | #31 Evidently AI (consolida #7+#8+#30 obligatorios) | 2026-04-30 | Rama `feature/model-decay-monitor` |
-| ⏳ Pendiente | Incremental learning (#36) | - | Migrar RandomForest → XGBoost con training en chunks. Resuelve OOM en training y habilita entrenar con histórico completo. |
+| 🔄 En review | Incremental learning XGBoost (#36) | 2026-05-07 | Migración RandomForest → XGBoost con training incremental en chunks mensuales. R² del modelo en producción: gas 0.869 / pet 0.895 (validado end-to-end). Resuelve OOM estructural y habilita entrenar con histórico completo. |
 | ⏳ Pendiente | #18 Segundo dataset del RFC | - | Información complementaria, no obligatorio |
 | ⏳ Pendiente | #9 + #10 Quick wins (eval desagregada + feature importance) | - | Mismo PR, toca `evaluate_model` |
 | ⏳ Pendiente | #16 CI/CD básico | - | GitHub Actions con tests + lint |
@@ -265,7 +265,7 @@ Reemplaza el filtro manual por un param `exclude_years=[2020]` por default. **De
 
 ---
 
-### En desarrollo — #31 Reporte de model decay con Evidently AI
+### #31 — Reporte de model decay con Evidently AI (mergeado 2026-05-01)
 
 **Rama:** `feature/model-decay-monitor`
 **Inicio:** 2026-04-30
@@ -429,6 +429,46 @@ PSI es el threshold estándar de la industria (PSI < 0.1 sin drift, 0.1-0.25 mod
 2. Verificar artefactos: HTML del reporte en MLFlow + métricas `monitor_r2`, `monitor_drift_share`, `monitor_r2_delta`.
 3. Commitear y abrir PR con CODEOWNERS auto-asignando review.
 4. Reiniciar `api-1` después del DAG para volver al setup completo.
+
+---
+
+### En desarrollo — #36 Incremental learning con XGBoost
+
+**Rama:** `feature/incremental-learning-xgboost`
+**Inicio:** 2026-05-02
+**Estado:** validación end-to-end completa ✅, PR pendiente de abrir.
+**Resuelve:** OOM estructural de `RandomForestRegressor.fit()` al entrenar con histórico extenso.
+
+#### Cambio conceptual
+
+Random Forest es un *bagging ensemble*: cada árbol se entrena sobre un bootstrap sample del dataset completo. La limitación de memoria es **algorítmica, no de implementación**: necesita acceso simultáneo a todo el dataset al armar cada árbol y por eso no tiene `partial_fit`. Con eso, entrenar localmente con histórico extenso (~2019 en adelante) era inviable.
+
+XGBoost es un *gradient boosting ensemble* construido secuencialmente: cada árbol nuevo aprende del error residual del modelo anterior. Esa propiedad permite *continuation*: cargar un modelo previo y agregarle árboles nuevos entrenando solo con un chunk de datos. La memoria queda acotada por el tamaño del chunk + el booster (chico, < 10 MB), no por el dataset total.
+
+**Aclaración:** la mejora no viene de cambiar el modelo solo. XGBoost con `xgb.fit(dataset_completo)` reproduce el mismo OOM. Son **dos cambios juntos**: (1) algoritmo que soporte continuación, y (2) bucle que itere el dataset por chunks.
+
+#### Decisiones tomadas durante la implementación
+
+1. **XGBoost sobre SGDRegressor.** SGDRegressor mantiene memoria estrictamente constante via `partial_fit`, pero es lineal — pierde la capacidad no-lineal valiosa para los features de ventana (`avg_prod_*_10m`, `last_prod_*`) y estáticos (`profundidad`). El tradeoff de memoria estrictamente constante no compensa la pérdida predictiva.
+2. **Chunks mensuales en orden temporal.** El split de Feast ya provee `event_timestamp`; iterar por mes es natural. El orden cronológico es deliberado: los meses recientes pesan más en el modelo final, lo cual es coherente con el caso de uso (predecir el mes siguiente).
+3. **`n_estimators_per_chunk` en lugar de `n_estimators`.** En XGBoost continuation, el parámetro pasa a ser "árboles a agregar por chunk", no "total". Con dataset de ~10 meses de train, `n_estimators_per_chunk=10` produce ~100 árboles totales. Renombrar el parámetro evita confusión.
+4. **`learning_rate=0.1`** (default de XGB es 0.3). Más conservador para que ningún chunk individual domine al modelo final.
+5. **Formato `.ubj` en MLFlow** (no pickle). `mlflow.xgboost.log_model(model_format="ubj")` preserva metadata específica de XGBoost y es portable entre versiones.
+6. **`event_timestamp` en X_train/X_test.** Para que `train_model` pueda iterar por mes. En las tasks que entrenan/predicen se filtra a `[features]` antes de pasar al modelo, así que nunca llega como feature.
+7. **`LabelEncoder` se mantiene** para `tipoextraccion`. XGBoost lo trata como ordinal numérico (subóptimo pero funciona). Migrar a `enable_categorical=True` queda para [issue #13](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/13).
+
+#### Validación end-to-end (run `manual__2026-05-07T22:22:24`)
+
+- **DAG completó exitosamente** las 27 tareas (download, prepare, online_store, split, 10 × train+evaluate, select_best_model, monitor_model). 0 fallos.
+- **Training:** ejemplo del primer experimento (prod_pet, 5 árboles/chunk): 31.940 samples procesados en **9 chunks mensuales**, 45 árboles totales en el modelo final.
+- **monitor_model:** R²=0.869 (gas), R²=0.895 (pet). Por encima del floor 0.85. drift_share=0.0 (PSI < 0.1 en todas las features, esperable porque train y test son del mismo año).
+- **Comparación con RandomForest anterior:** RF logra 0.872/0.910, XGBoost logra 0.869/0.895. Caída marginal (~0.3% / ~1.5%) explicable por el menor número de árboles totales (45-90 vs 100) y `learning_rate=0.1` conservador. Tradeoff aceptable a cambio de poder escalar en memoria.
+- **Memoria:** training en chunks no provocó picos de RAM perceptibles, a diferencia del RF que generaba presión cerca del límite.
+
+#### Lo que NO resuelve esta feature
+
+- OOM en `prepare_offline_store` (carga del CSV + `groupby` + `rolling` con pandas in-memory). Es un cuello de botella separado, antes del training. Issue futura: refactorear a procesamiento por chunks o usar Dask/Polars.
+- Presión de RAM por containers simultáneos. Sigue siendo necesario parar `api-1` durante el DAG run o subir RAM de Docker Desktop.
 
 ---
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -11,8 +11,8 @@
 | ✅ Mergeado | #24 Cierre de #12 (CSV hash) | 2026-04-30 | Supuesto de inmutabilidad aceptado |
 | ✅ Mergeado | #29 Ray Serve (cubre #6 obligatorio) | 2026-04-30 | `num_replicas=2` unificado |
 | ✅ Mergeado | #25 Filtro automático COVID | 2026-04-30 | Default `exclude_years=[2020]` |
-| 🔄 En curso | #31 Evidently AI (consolida #7+#8+#30 obligatorios) | 2026-04-30 | Rama `feature/model-decay-monitor` |
-| 🔄 En review | Incremental learning XGBoost (#36) | 2026-05-07 | Migración RandomForest → XGBoost con training incremental en chunks mensuales. R² del modelo en producción: gas 0.869 / pet 0.895 (validado end-to-end). Resuelve OOM estructural y habilita entrenar con histórico completo. |
+| ✅ Mergeado | #31 Evidently AI (consolida #7+#8+#30 obligatorios) | 2026-05-01 | Mergeado en PR #35. Cubre obligatorio del RFC con R² delta + drift_share via PSI |
+| 🔄 En review | Incremental learning XGBoost (#36) | 2026-05-07 | PR #37 abierto. Migración RandomForest → XGBoost con training incremental en chunks mensuales. R² del modelo en producción: gas 0.869 / pet 0.895 (validado end-to-end). Resuelve OOM estructural y habilita entrenar con histórico completo. |
 | ⏳ Pendiente | #18 Segundo dataset del RFC | - | Información complementaria, no obligatorio |
 | ⏳ Pendiente | #9 + #10 Quick wins (eval desagregada + feature importance) | - | Mismo PR, toca `evaluate_model` |
 | ⏳ Pendiente | #16 CI/CD básico | - | GitHub Actions con tests + lint |
@@ -32,10 +32,10 @@
 
 ## Requerimientos obligatorios pendientes
 
-Tras releer el RFC, los obligatorios (DEBE) están todos en marcha o cerrados:
+Tras releer el RFC, los dos obligatorios (DEBE) están cerrados:
 
 - ✅ **Arquitectura escalable de inferencia (Ray):** cubierto por #29 (Ray Serve) — mergeado.
-- 🔄 **Reporte de model decay / data drift con al menos dos métricas:** en curso en #31 (Evidently AI).
+- ✅ **Reporte de model decay / data drift con al menos dos métricas:** cubierto por #31 (Evidently AI) — mergeado en PR #35 (2026-05-01).
 
 ---
 
@@ -43,9 +43,9 @@ Tras releer el RFC, los obligatorios (DEBE) están todos en marcha o cerrados:
 
 **Requisito:** El sistema DEBE dar un reporte de model decay, data drift / concept drift con al menos dos métricas que permitan observar cuándo la performance del modelo se aleja de la esperada.
 
-**Estado:** ❌ No implementado.
+**Estado:** ✅ Implementado en #31 (mergeado en PR #35, 2026-05-01). Ver bitácora más abajo para el detalle de decisiones e iteraciones. La sección a continuación es la propuesta original de diseño que guió la implementación.
 
-**Propuesta de implementación:**
+**Propuesta de implementación original:**
 
 Agregar una tarea `monitor_model` al final del DAG (después de `select_best_model`) que compare el modelo recién entrenado contra la versión anterior en producción y genere un reporte con estas métricas:
 
@@ -79,9 +79,9 @@ La ponderación refleja prioridades del problema: R² es el indicador principal 
 
 **Requisito:** El sistema DEBE implementar una arquitectura escalable para responder la inferencia de la API (ej: Ray).
 
-**Estado:** ❌ No implementado. La API actual corre con un único proceso uvicorn dentro del contenedor Airflow.
+**Estado:** ✅ Implementado en #29 (mergeado 2026-04-30) con Ray Serve + FastAPI, `num_replicas=2` unificado. Ver Decisión #10 del README para el detalle arquitectónico. La sección a continuación es la propuesta original que guió la implementación.
 
-**Propuesta de implementación:**
+**Propuesta de implementación original:**
 
 Reemplazar el servidor uvicorn simple por Ray Serve:
 
@@ -269,7 +269,7 @@ Reemplaza el filtro manual por un param `exclude_years=[2020]` por default. **De
 
 **Rama:** `feature/model-decay-monitor`
 **Inicio:** 2026-04-30
-**Estado:** En desarrollo, validación en curso del DAG end-to-end.
+**Estado:** ✅ Mergeado en PR #35 (2026-05-01). Cierra obligatorio del RFC.
 **Cubre obligatorio del RFC:** "El sistema DEBE dar un reporte de model decay / data drift con al menos dos métricas que permitan observar cuándo la performance del modelo se aleja de la esperada."
 **Consolida issues:** #7 (model decay report), #8 (threshold configurable), motivación de #30 (alibi-detect, cerrado).
 
@@ -423,20 +423,20 @@ PSI es el threshold estándar de la industria (PSI < 0.1 sin drift, 0.1-0.25 mod
 
 **Lección general:** para data drift en pipelines automáticos donde el tamaño de muestra varía de un run a otro, **preferir métricas de magnitud sobre tests de hipótesis**. Los p-values son útiles para decisiones puntuales con muestras chicas; las métricas de magnitud son más robustas en producción.
 
-#### Próximos pasos para cerrar #31
+#### Cómo se cerró #31
 
-1. Validar la corrida end-to-end después del fix de Evidently 0.6.7.
-2. Verificar artefactos: HTML del reporte en MLFlow + métricas `monitor_r2`, `monitor_drift_share`, `monitor_r2_delta`.
-3. Commitear y abrir PR con CODEOWNERS auto-asignando review.
-4. Reiniciar `api-1` después del DAG para volver al setup completo.
+1. ✅ Validada la corrida end-to-end después del fix de Evidently 0.6.7.
+2. ✅ Verificados artefactos: HTML del reporte en MLFlow + métricas `monitor_r2`, `monitor_drift_share`, `monitor_r2_delta`.
+3. ✅ PR abierto, revisado y mergeado como PR #35.
+4. ✅ Setup completo restaurado tras el DAG run.
 
 ---
 
-### En desarrollo — #36 Incremental learning con XGBoost
+### 🔄 En review — #36 Incremental learning con XGBoost
 
 **Rama:** `feature/incremental-learning-xgboost`
 **Inicio:** 2026-05-02
-**Estado:** validación end-to-end completa ✅, PR pendiente de abrir.
+**Estado:** validación end-to-end completa ✅, PR #37 abierto y en review.
 **Resuelve:** OOM estructural de `RandomForestRegressor.fit()` al entrenar con histórico extenso.
 
 #### Cambio conceptual

--- a/roadmap.md
+++ b/roadmap.md
@@ -13,20 +13,52 @@
 | ✅ Mergeado | #25 Filtro automático COVID | 2026-04-30 | Default `exclude_years=[2020]` |
 | ✅ Mergeado | #31 Evidently AI (consolida #7+#8+#30 obligatorios) | 2026-05-01 | Mergeado en PR #35. Cubre obligatorio del RFC con R² delta + drift_share via PSI |
 | 🔄 En review | Incremental learning XGBoost (#36) | 2026-05-07 | PR #37 abierto. Migración RandomForest → XGBoost con training incremental en chunks mensuales. R² del modelo en producción: gas 0.869 / pet 0.895 (validado end-to-end). Resuelve OOM estructural y habilita entrenar con histórico completo. |
-| ⏳ Pendiente | #18 Segundo dataset del RFC | - | Información complementaria, no obligatorio |
-| ⏳ Pendiente | #9 + #10 Quick wins (eval desagregada + feature importance) | - | Mismo PR, toca `evaluate_model` |
-| ⏳ Pendiente | #16 CI/CD básico | - | GitHub Actions con tests + lint |
-| ⏳ Pendiente | #11 OpenAPI descriptions | - | Solo `main.py` |
-| ⏳ Pendiente | #13 LabelEncoder como artefacto | - | Persistir como pickle en MLFlow |
-| ⏳ Pendiente | #14 Validación de schema | - | `pandera` en `download_dataset` |
-| ⏳ Pendiente | #15 Prediction logging | - | CSV/SQLite en `main.py` |
-| ⏳ Pendiente | #17 Point-in-Time correct | - | Más complejo, solo si hay tiempo |
+**Pendientes consolidados en el [Backlog priorizado](#backlog-priorizado) más abajo** — incluye los issues del roadmap original (#9, #10, #11, #13, #14, #15, #16, #17, #18) y los detectados durante reviews de las clases 6, 7 y 8 (#26, #27, #28, #38, #39, #40-44, #46-48).
 
 **Notas sobre la evolución del scope:**
 
 - **#6 (Ray Serve):** ya implementado en [PR #29](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/pull/29). Era obligatorio del RFC (arquitectura escalable para inferencia).
 - **#7 + #8 + #30 consolidados en #31 (Evidently AI):** inicialmente se planteaban tres issues separados — reporte propio de model decay (#7), threshold configurable (#8) y drift detection con `alibi-detect` (#30). Al evaluar la implementación apareció Evidently AI, que cubre las tres cosas con una única librería (regression performance + data drift + tests asertivos con umbrales). Se cerró #30 y se consolidó todo el scope en #31, lo cual simplifica la arquitectura y reduce el mantenimiento.
 - **#23 (filtro COVID 2020):** cubierto en [PR #25](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/pull/25) con un mecanismo más general (`exclude_years` en lugar de hardcodear 2020).
+
+---
+
+## Backlog priorizado
+
+Issues abiertos ordenados por importancia. Los dos obligatorios del RFC ya están cerrados (#29 Ray Serve + #31 Evidently), por lo que esta priorización refleja **valor incremental** sobre el sistema, no urgencia para la entrega.
+
+Criterio de los niveles:
+
+- **P1 — Operativos críticos**: previenen fallos silenciosos y endurecen el sistema. Bajo esfuerzo, alto impacto preventivo.
+- **P2 — Observabilidad y monitoreo**: dan visibilidad sobre qué pasa en producción y completan el monitoreo iniciado en #31.
+- **P3 — Calidad del pipeline**: cierran gaps de best practices identificados en el README y reviews.
+- **P4 — Robustez estructural**: cambios más invasivos pero importantes para escala (memoria, CI/CD, point-in-time).
+- **P5 — Optimizaciones data-driven**: requieren datos previos (latencia medida, asimetría observada) para justificarse — abrir solo cuando haya evidencia.
+
+| Prioridad | Issue | Notas |
+|---|---|---|
+| **P1** | [#46](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/46) Alerta de modelo stale | Detecta DAG fallando silenciosamente. Endpoint `/health/staleness` o tarea Airflow independiente. Origen: Clase 7, Caso 1 YarnIt. |
+| **P1** | [#47](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/47) Validación de outputs (NaN / rangos físicos) | Defensivo. Evita devolver predicciones absurdas (negativas, NaN) al consumidor. Origen: Clase 7, slide 62. |
+| **P1** | [#14](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/14) Validación de schema CSV con pandera | Detecta cambios upstream en el dataset MINEM antes de romper en una tarea posterior. Origen: roadmap original. |
+| **P1** | [#42](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/42) Health check + graceful degradation | Endpoints `/health/live` y `/health/ready` + fallback al modelo cacheado en disco. Origen: Clase 6, slides 36 y 52. |
+| **P1** | [#41](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/41) Autenticación API key | Hoy `/api/v1/*` están abiertos. Mínimo: `X-API-Key` validado contra `.env`. Origen: Clase 6, slide 52. |
+| **P2** | [#40](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/40) Métricas de latencia P50/P90/P99 | Prerrequisito para definir SLA y para validar #27/#28. Origen: Clase 6, slides 7, 27, 52. |
+| **P2** | [#44](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/44) Logs operacionales estructurados (JSON) | Distinto de #15: logs de sistema, no de predicciones. Base para debugging serio. Origen: Clase 6, slide 51. |
+| **P2** | [#15](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/15) Prediction logging en API | CSV/SQLite con `(id_well, date, target, pred, features, timestamp)`. Habilita análisis de drift en producción. Origen: roadmap original. |
+| **P2** | [#48](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/48) Bias y calibration en `monitor_model` | Completa la tríada de canary metrics. Hoy hay R² delta + drift_share, faltan bias y calibración por bucket. Origen: Clase 7, slide 11. |
+| **P2** | [#43](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/43) Prometheus + Grafana | Stack estándar para observabilidad operativa. Depende de #40 (necesita endpoint `/metrics`). Origen: Clase 6, slide 51. |
+| **P3** | [#9](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/9) Eval desagregada por `tipoextraccion` | Quick win en `evaluate_model`. Detecta disparate impact por subgrupo. Origen: roadmap original (ética IA). |
+| **P3** | [#10](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/10) Feature importance en MLFlow | Quick win, mismo PR que #9. Una línea por feature por target. Origen: roadmap original (XAI). |
+| **P3** | [#13](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/13) LabelEncoder como artefacto | Cierra training-serving skew latente si aparecen nuevas categorías de `tipoextraccion`. Origen: roadmap original. |
+| **P3** | [#11](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/11) OpenAPI descriptions en endpoints | Mejora usabilidad del Swagger UI con descriptions y ejemplos por param. Origen: roadmap original. |
+| **P4** | [#38](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/38) Refactor `split_data` y `prepare_offline_store` por chunks | El siguiente bottleneck post-XGBoost — Feast cargando todo en RAM. Habilita entrenar con 3+ años. Origen: bitácora #36. |
+| **P4** | [#16](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/16) CI/CD básico con GitHub Actions | Tests + lint + validación de schema en cada PR. Lleva al Nivel 2 de MLOps. Origen: roadmap original. |
+| **P4** | [#17](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/17) Point-in-Time correct con `entity_df` en Feast | Robustez del entrenamiento ante mutaciones retroactivas del dataset upstream. Origen: roadmap original. |
+| **P4** | [#18](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/18) Segundo dataset del RFC | Metadata estructural por pozo (formación, cuenca, empresa). Complementa el modelo. Origen: roadmap original. |
+| **P5** | [#27](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/27) Cache de inferencia con Redis | Optimización condicional. Justificada solo si #40 muestra que la CPU del API es bottleneck. Origen: Clase 6. |
+| **P5** | [#28](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/28) Autoscaling dinámico de Ray Serve | Optimización condicional. Justificada solo si #40 muestra utilización desigual. Origen: Clase 6. |
+| **P5** | [#26](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/26) Separación de deployments gas/pet | Justificada solo si #15 muestra asimetría sostenida de carga entre fluidos. Origen: Clase 6 / Decisión #10 README. |
+| **P5** | [#39](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/39) Adaptive Isolation Forest | Exploratorio para `monitor_model`. No aplica directamente al caso de uso (no es clasificación de fraude). Origen: Clase 7. |
 
 ---
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -461,14 +461,73 @@ XGBoost es un *gradient boosting ensemble* construido secuencialmente: cada árb
 
 - **DAG completó exitosamente** las 27 tareas (download, prepare, online_store, split, 10 × train+evaluate, select_best_model, monitor_model). 0 fallos.
 - **Training:** ejemplo del primer experimento (prod_pet, 5 árboles/chunk): 31.940 samples procesados en **9 chunks mensuales**, 45 árboles totales en el modelo final.
-- **monitor_model:** R²=0.869 (gas), R²=0.895 (pet). Por encima del floor 0.85. drift_share=0.0 (PSI < 0.1 en todas las features, esperable porque train y test son del mismo año).
-- **Comparación con RandomForest anterior:** RF logra 0.872/0.910, XGBoost logra 0.869/0.895. Caída marginal (~0.3% / ~1.5%) explicable por el menor número de árboles totales (45-90 vs 100) y `learning_rate=0.1` conservador. Tradeoff aceptable a cambio de poder escalar en memoria.
 - **Memoria:** training en chunks no provocó picos de RAM perceptibles, a diferencia del RF que generaba presión cerca del límite.
 
-#### Lo que NO resuelve esta feature
+#### Validación cuantitativa con 3 escenarios de rango temporal
 
-- OOM en `prepare_offline_store` (carga del CSV + `groupby` + `rolling` con pandas in-memory). Es un cuello de botella separado, antes del training. Issue futura: refactorear a procesamiento por chunks o usar Dask/Polars.
-- Presión de RAM por containers simultáneos. Sigue siendo necesario parar `api-1` durante el DAG run o subir RAM de Docker Desktop.
+Después de la validación end-to-end inicial, se diseñó un experimento más riguroso para cuantificar el tradeoff RF vs XGBoost. La idea: correr el DAG con tres rangos temporales crecientes (A: 2 años, B: 3 años, C: 4 años efectivos) en ambos modelos y medir tiempo, RAM y performance.
+
+**Tabla 1 — Resumen ejecutivo**
+
+| Escenario | Modelo | Estado | Tiempo total | Tiempo train_model (suma 10 exp) | RAM peak worker |
+|---|---|---|---|---|---|
+| A (2022-2023) | XGBoost | ✅ success | **244s** | **45s** | **2.99 GiB** |
+| A (2022-2023) | RandomForest | ✅ success | 469s | 211s | 3.53 GiB |
+| B (2020-2023) | XGBoost | ❌ failed en `split_data` | 98s | (no llegó) | 3.67 GiB |
+| B (2020-2023) | RandomForest | (saltado, fallaría idéntico) | — | — | — |
+| C (2019-2023) | XGBoost | (saltado, fallaría idéntico) | — | — | — |
+| C (2019-2023) | RandomForest | (saltado, fallaría idéntico) | — | — | — |
+
+**Tabla 2 — Setup**
+
+| Escenario | Modelo | Filas X_train | Árboles totales | Hiperparámetros clave |
+|---|---|---|---|---|
+| A | XGBoost | 63.424 | 95 (5 × 19 chunks) | est_pc=5, depth=6, lr=0.1 |
+| A | RandomForest | 63.424 | 100 | est=100, depth=10 |
+
+**Tabla 3 — Performance (escenario A, único comparable)**
+
+| Modelo | R² gas | R² pet | RMSE gas (m³) | RMSE pet (m³) | MAE gas (m³) | MAE pet (m³) |
+|---|---|---|---|---|---|---|
+| XGBoost | 0.871 | 0.863 | 668,9 | 393,8 | 193,3 | 122,4 |
+| RandomForest | **0.923** | **0.902** | **517,4** | **334,4** | **141,7** | **93,7** |
+| Δ (RF − XGB) | +5,2 pp | +3,9 pp | −151,5 (−23%) | −59,4 (−15%) | −51,6 (−27%) | −28,7 (−24%) |
+
+**Lectura del experimento:**
+
+- **XGBoost gana en eficiencia operativa**: ~2× más rápido total, ~5× más rápido específicamente en `train_model`, 15% menos RAM peak. En producción mensual estos ahorros son reales.
+- **RandomForest gana en precisión** en este rango chico: R² entre 4 y 5 pp mejor, RMSE 15-23% menor.
+- **B y C revelan el siguiente cuello de botella**: con 3+ años, ambos modelos fallan en `split_data` por OOM. La razón no es el modelo: es Feast cargando todo en memoria al hacer `get_historical_features`, antes incluso de empezar a entrenar.
+
+#### Tuning fallido — la config conservadora era el techo
+
+Tras ver la pérdida de performance, se intentó tunear XGBoost con configuraciones más agresivas (max_depth=8-10, learning_rate=0.1-0.2, est_pc=10-15) bajo la hipótesis de que la config original era subóptima por árboles muy chicos y learning_rate muy bajo.
+
+**Resultado: todos los experimentos empeoraron.**
+
+| Configuración | R² gas | R² pet | Diagnóstico |
+|---|---|---|---|
+| depth=6, lr=0.1, est_pc=5 (original) | 0.871 | 0.863 | Baseline. |
+| depth=10, lr=0.1, est_pc=10 | 0.661 | 0.673 | −0,21 pp |
+| depth=10, lr=0.2, est_pc=10 | −0.04 | −0.24 | Catastrófico. |
+| depth=8, lr=0.1, est_pc=15 | 0.458 | 0.484 | −0,41 pp |
+| depth=8, lr=0.2, est_pc=10 | −0.08 | 0.217 | Catastrófico. |
+| depth=10, lr=0.1, reduced features | −0.46 | −0.07 | Catastrófico. |
+
+**Diagnóstico — overfitting estructural por incremental + árboles profundos:**
+
+Con `max_depth=10` cada árbol es muy expresivo. Con 19 chunks × 10 árboles = 190 árboles muy expresivos acumulados. Cada chunk se ajusta al residuo de su mes específico y memoriza patrones locales. El test set es contiguous a los meses finales del train (split temporal 80/20 sobre fechas), entonces los chunks finales overfittean justo donde se va a evaluar. `learning_rate=0.2` acelera el efecto.
+
+**Aprendizaje: la pérdida de R² ~5 pp vs RandomForest no es por subóptima configuración — es el costo intrínseco del incremental learning con árboles en este dataset.** Subir capacidad expresiva (depth) o agresividad (lr) empeora porque ya estábamos en el sweet spot.
+
+Se vuelve a la configuración original (depth=6, lr=0.1, est_pc=5) y se acepta el tradeoff documentado.
+
+#### Lo que NO resuelve esta feature (próximos cuellos de botella)
+
+1. **`split_data` y `prepare_offline_store` siguen cargando todo en memoria.** Los escenarios B y C fallaron acá, antes del training. **Es el siguiente bottleneck prioritario** — issue separado a abrir: refactorear estas tareas a procesamiento por chunks o migrar de pandas in-memory a Dask/Polars. **Resolver esto desbloquea dos mejoras independientes que pueden compensar la pérdida de performance:**
+   - Entrenar con histórico completo (B/C escenarios). XGBoost con más datos típicamente mejora; el escalado a 4+ años puede acercar la performance a RF e incluso superarla en datos más recientes.
+   - Sumar el segundo dataset del RFC ([#18](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/18)) con metadata estructural por pozo (formación geológica, cuenca, empresa). Esos features tienen capacidad explicativa que hoy no está en el modelo y podrían cerrar la brecha vs RandomForest.
+2. **Presión de RAM por containers simultáneos.** Sigue siendo necesario parar `api-1` durante el DAG run o subir RAM de Docker Desktop.
 
 ---
 


### PR DESCRIPTION
## Resumen

Migra el training de `RandomForestRegressor` a `XGBRegressor` con **continuation training** por chunks mensuales. Cierra [#36](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/36).

## El problema

`RandomForestRegressor.fit()` carga el dataset completo en RAM. Limitación **algorítmica**, no de implementación: RF es bagging — cada árbol necesita acceso simultáneo a todo el dataset para el bootstrap. Por eso no tiene `partial_fit` y no puede tenerlo. Resultado: entrenar localmente con histórico extenso (~2019 en adelante) era inviable, OOM garantizado.

## La solución

XGBoost es gradient boosting secuencial: cada árbol nuevo aprende del error residual del anterior. Esa propiedad permite *continuation*: cargar un modelo previo y agregarle árboles entrenando solo con un chunk. Con eso se itera el dataset por mes y la memoria queda acotada por `chunk + booster_chico` (~MB), no por el dataset total (~GB con histórico extenso).

**Aclaración importante:** la mejora viene de **dos cambios juntos**, no del modelo solo. (1) Algoritmo que soporte continuación + (2) bucle que itere el dataset por chunks. XGBoost con `xgb.fit(dataset_completo)` reproduce el mismo OOM que RF.

## Cambios

- **`dags/dag_oil_and_gas.py`:**
  - `train_model` refactoreado: itera `X_train` por mes (`event_timestamp.dt.to_period('M')`), entrena con `XGBRegressor.fit(..., xgb_model=prev_path)`, guarda booster en `.ubj`. Cada chunk agrega `n_estimators_per_chunk` árboles al final del booster.
  - `evaluate_model` carga con `xgb.XGBRegressor().load_model(path)` (no pickle) y loguea con `mlflow.xgboost.log_model(model_format="ubj")` (no `mlflow.sklearn`).
  - `monitor_model` carga production con `mlflow.xgboost.load_model`. La lógica de Evidently (`feature_names_in_`, predict, drift report) es transparente al cambio de modelo.
  - `select_best_model` no cambia.
  - `split_data`: `event_timestamp` ya no se dropea de X_train/X_test (se filtra a `[features]` en train/evaluate antes del modelo, pero queda disponible para iterar por mes).
  - Lista `EXPERIMENTS` adaptada: `n_estimators_per_chunk` (nuevo) en lugar de `n_estimators`, `learning_rate=0.1` agregado, `max_depth` variando entre 4/6/8.
- **`api/main.py`:** `mlflow.sklearn.load_model` → `mlflow.xgboost.load_model`. Cambio mínimo, transparente al cliente.
- **`.env`:** agregado `xgboost==3.2.0` a `_PIP_ADDITIONAL_REQUIREMENTS`.
- **`README.md`:** decisión de diseño #13 con la migración documentada (algoritmo, memoria, hiperparámetros, tradeoffs).
- **`roadmap.md`:** entrada cerrada en bitácora con decisiones tomadas y resultados de la validación end-to-end.

## Validación end-to-end

DAG corrido exitoso (`manual__2026-05-07T22:22:24`):

- **27 tareas exitosas, 0 fallos.**
- **Training:** primer experimento (prod_pet, 5 árboles/chunk) procesó **31.940 samples en 9 chunks mensuales** = 45 árboles totales en el modelo final.
- **monitor_model:**
  ```
  oil_gas_prod_gas: R²=0.869, drift_share=0.0, delta_r2=+0.422
  oil_gas_prod_pet: R²=0.895, drift_share=0.0, delta_r2=+0.353
  ```
- **Comparación con RandomForest anterior:** RF lograba 0.872/0.910, XGBoost logra 0.869/0.895. Caída marginal (~0.3% gas, ~1.5% pet), explicable por menor cantidad total de árboles (45-90 vs 100) y `learning_rate=0.1` conservador. **Tradeoff aceptable** a cambio de poder escalar en memoria.

## Hiperparámetros que cambiaron

| RandomForest (anterior) | XGBoost (actual) | Notas |
|---|---|---|
| `n_estimators=100` (total) | `n_estimators_per_chunk=5/10` (por mes) | Pitfall: en continuation es árboles a agregar, **no total**. Con ~10 meses de train se llega a ~50-100 totales. |
| `max_depth=10` o `None` | `max_depth=4/6/8` | XGBoost tiende a generalizar mejor con árboles conservadores. |
| (no aplica) | `learning_rate=0.1` | Default de XGB es 0.3 — agresivo para incremental. 0.1 es más estable: ningún chunk domina. |

## Lo que NO resuelve este PR (issues futuras)

- **OOM en `prepare_offline_store`** (carga del CSV completo + `groupby` + `rolling`). Cuello de botella separado, antes del training. Issue futura: chunks o Dask/Polars.
- **Presión total de containers** (Ray Serve + entrenamiento + Evidently). Sigue siendo necesario parar `api-1` durante el DAG o subir RAM de Docker Desktop.
- **`enable_categorical=True`** para `tipoextraccion`. Hoy se sigue usando `LabelEncoder`; XGBoost lo trata como ordinal numérico (subóptimo). Cubierto por [issue #13](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/13).

## Test plan

- [x] Validar que el DAG completa end-to-end con `date_from=2023-01-01, date_to=2023-12-31`.
- [x] Confirmar que `monitor_model` reporta R² razonable y drift_share válido.
- [x] Confirmar que el modelo se loguea como XGBoost en MLFlow (no como sklearn).
- [x] (Reviewer) Verificar que la API levanta correctamente con el nuevo `mlflow.xgboost.load_model`.
- [x] (Reviewer) Smoke test con un rango más grande (ej. 2022-2023) para confirmar que el incremental escala.

## Requisitos de entorno

⚠️ Antes de correr el DAG localmente, parar `api-1` para liberar RAM:
```bash
docker compose stop api
# trigger DAG
docker compose start api  # cuando termine
```