### PR TITLE
feat: agregar task validate_dataset para validación de schema del CSV…

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,31 @@ Conviene aclarar que **el proyecto sí implementa continual learning, pero a la 
 
 La slide 50 de la clase plantea exactamente este trade-off: "si un modelo XGBoost estático alcanza 86 % y la variante en streaming logra 88 %, el impacto de negocio de ese +2 % debe justificar el aumento de infraestructura". En este caso, ese +2 % no compensa el orden de magnitud de complejidad operativa que sumaría streaming. La conclusión coincide con la slide 51 de la clase: continual learning aplica para "motores publicitarios, pricing dinámico, mercados financieros, ciberseguridad" — no para predicción de producción regulatoria con cadencia mensual.
 
+### 16. Validación de schema del CSV al ingestar
+
+El pipeline asume una estructura de datos fija del CSV del MINEM. Si el gobierno cambia el nombre de una columna, reordena las columnas, o agrega un campo nuevo, el error aparece en `prepare_offline_store` (o incluso más tarde, en el entrenamiento) como un `KeyError` o un resultado incorrecto silencioso — difícil de diagnosticar.
+
+#### Solución: task `validate_dataset` antes de `prepare_offline_store`
+
+Se agregó una nueva task en el DAG que actúa como **contrato explícito entre la fuente de datos y el pipeline**. Corre inmediatamente después de `download_dataset` y antes de cualquier procesamiento:
+
+1. **Columnas requeridas**: verifica que las 9 columnas que el pipeline consume (`idpozo`, `anio`, `mes`, `prod_gas`, `prod_pet`, `tipoextraccion`, `profundidad`, `tef`, `prod_agua`) estén presentes. Si falta alguna, el DAG falla aquí con la lista exacta de columnas faltantes.
+2. **Columnas críticas no vacías**: verifica que `idpozo`, `prod_gas`, `prod_pet`, `anio` y `mes` no estén completamente vacías en la muestra inicial.
+3. **Rango de años razonable**: verifica que los valores de `anio` caigan entre 2010 y 2030. Detecta datos corruptos o columnas reordenadas que hacen que un campo numérico distinto sea interpretado como año.
+4. **Mínimo de filas**: cuenta las líneas del archivo completo por streaming (sin cargarlo en RAM) y verifica que haya al menos 100 filas. Detecta descargas incompletas.
+
+#### Por qué chequeo manual en lugar de pandera
+
+El roadmap original (#14) proponía usar `pandera`. Se optó por validación manual con pandas porque:
+
+- No agrega dependencias externas al `_PIP_ADDITIONAL_REQUIREMENTS` del DAG (el container worker ya tiene huella alta por Evidently + MLflow).
+- Las validaciones necesarias son simples (presencia de columnas, rangos, no-nulos): no requieren la expresividad de un framework de contratos.
+- Consistente con el criterio de complejidad mínima aplicado en otras decisiones del pipeline (Decisión #7, Decisión #8).
+
+#### Impacto en el flujo
+
+El task es no-destructivo: si todas las validaciones pasan, devuelve el mismo `csv_path` sin modificar el archivo. El resto del DAG continúa exactamente igual. Si alguna falla, el pipeline aborta con un `ValueError` descriptivo antes de que cualquier dato corrupto llegue al feature store o al modelo.
+
 ---
 
 ## Feature Store

--- a/dags/dag_oil_and_gas.py
+++ b/dags/dag_oil_and_gas.py
@@ -87,6 +87,91 @@ def ml_pipeline():
     return save_path
 
   @task
+  def validate_dataset(csv_path):
+    """
+    Valida el schema y calidad básica del CSV descargado antes de procesarlo.
+
+    Actúa como contrato explícito entre la fuente de datos (MINEM) y el pipeline:
+    si el CSV cambia de estructura, falla aquí con un mensaje claro en lugar de
+    producir un error críptico en prepare_offline_store o durante el entrenamiento.
+
+    Verifica:
+    - Que las columnas requeridas por el pipeline existan.
+    - Que las columnas críticas no estén completamente vacías.
+    - Que el rango de años sea razonable (detecta datos corruptos o columnas reordenadas).
+    - Que el archivo tenga un mínimo de filas (detecta descargas incompletas).
+
+    No carga el CSV completo en memoria: usa pd.read_csv con nrows para el
+    chequeo de schema y un conteo de líneas por streaming para el chequeo de volumen.
+
+    Args: csv_path (str) - ruta al CSV descargado por download_dataset.
+    Retorna: csv_path sin modificar (para encadenar con prepare_offline_store).
+    Raises: ValueError si alguna validación falla.
+
+    Ver Decisión #16 en el README.
+    """
+    import logging
+
+    log = logging.getLogger(__name__)
+
+    REQUIRED_COLUMNS = {'idpozo', 'anio', 'mes', 'prod_pet', 'prod_gas', 'tipoextraccion', 'profundidad', 'tef', 'prod_agua'}
+    CRITICAL_COLUMNS = {'idpozo', 'prod_gas', 'prod_pet', 'anio', 'mes'}
+    MIN_ROWS        = 100
+    YEAR_MIN        = 2010
+    YEAR_MAX        = 2030
+
+    # Leemos solo las primeras 1000 filas para el chequeo de schema y valores.
+    # No hace falta ver el dataset completo para validar estructura y rango de años.
+    df_sample = pd.read_csv(csv_path, nrows=1000)
+
+    # 1. Columnas requeridas
+    missing = REQUIRED_COLUMNS - set(df_sample.columns)
+    if missing:
+      raise ValueError(
+        f"validate_dataset: columnas faltantes en el CSV: {sorted(missing)}. "
+        f"Columnas presentes: {list(df_sample.columns)}. "
+        f"¿Cambió la estructura del archivo del MINEM?"
+      )
+    log.info(f"validate_dataset: ✓ columnas requeridas presentes ({len(REQUIRED_COLUMNS)} columnas)")
+
+    # 2. Columnas críticas no completamente vacías
+    for col in CRITICAL_COLUMNS:
+      if df_sample[col].isna().all():
+        raise ValueError(
+          f"validate_dataset: columna crítica '{col}' está completamente vacía en el CSV. "
+          f"Revisar la fuente de datos del MINEM."
+        )
+    log.info(f"validate_dataset: ✓ columnas críticas con datos en las primeras {len(df_sample)} filas")
+
+    # 3. Rango de años razonable (detecta datos corruptos o columnas reordenadas)
+    years = df_sample['anio'].dropna()
+    if len(years) > 0:
+      year_min_found = int(years.min())
+      year_max_found = int(years.max())
+      if year_min_found < YEAR_MIN or year_max_found > YEAR_MAX:
+        raise ValueError(
+          f"validate_dataset: rango de años fuera de lo esperado: [{year_min_found}, {year_max_found}]. "
+          f"Rango válido: [{YEAR_MIN}, {YEAR_MAX}]. "
+          f"¿Datos corruptos o columnas reordenadas en el CSV?"
+        )
+      log.info(f"validate_dataset: ✓ rango de años válido [{year_min_found}, {year_max_found}]")
+
+    # 4. Mínimo de filas en el archivo completo (detecta descargas incompletas).
+    # Contamos líneas por streaming para no cargar el CSV entero en RAM.
+    with open(csv_path, 'r', encoding='utf-8', errors='replace') as f:
+      row_count = sum(1 for _ in f) - 1  # -1 por el header
+
+    if row_count < MIN_ROWS:
+      raise ValueError(
+        f"validate_dataset: el CSV tiene solo {row_count} filas (mínimo esperado: {MIN_ROWS}). "
+        f"¿Descarga incompleta o URL del MINEM cambiada?"
+      )
+    log.info(f"validate_dataset: ✓ {row_count:,} filas totales en el CSV")
+
+    log.info("validate_dataset: todas las validaciones pasaron. Pipeline listo para continuar.")
+    return csv_path
+
+  @task
   def prepare_offline_store(read_csv_path, feature_store_repo, **context):
     """
     Lee el CSV, calcula los features de ventana para cada pozo y mes, y genera el offline store.
@@ -705,9 +790,12 @@ def ml_pipeline():
       save_path = '/opt/airflow/data/pozos.csv'
   )
 
+  # Validamos schema y calidad básica del CSV antes de procesarlo (cierra #14)
+  validated_csv = validate_dataset(csv_path)
+
   # Preparamos el offline store y registramos en Feast
   offline_store = prepare_offline_store(
-      read_csv_path = csv_path,
+      read_csv_path = validated_csv,
       feature_store_repo = FEATURE_STORE_REPO
   )
 
@@ -722,7 +810,7 @@ def ml_pipeline():
   )
 
   # Definimos dependencias iniciales
-  start >> csv_path >> offline_store >> online_store >> splits
+  start >> csv_path >> validated_csv >> offline_store >> online_store >> splits
 
   # Loop sobre los experimentos encadenados en serie
   prev_task = splits

--- a/roadmap.md
+++ b/roadmap.md
@@ -12,7 +12,8 @@
 | ✅ Mergeado | #29 Ray Serve (cubre #6 obligatorio) | 2026-04-30 | `num_replicas=2` unificado |
 | ✅ Mergeado | #25 Filtro automático COVID | 2026-04-30 | Default `exclude_years=[2020]` |
 | ✅ Mergeado | #31 Evidently AI (consolida #7+#8+#30 obligatorios) | 2026-05-01 | Mergeado en PR #35. Cubre obligatorio del RFC con R² delta + drift_share via PSI |
-| 🔄 En review | Incremental learning XGBoost (#36) | 2026-05-07 | PR #37 abierto. Migración RandomForest → XGBoost con training incremental en chunks mensuales. R² del modelo en producción: gas 0.869 / pet 0.895 (validado end-to-end). Resuelve OOM estructural y habilita entrenar con histórico completo. |
+| ✅ Mergeado | Incremental learning XGBoost (#36) | 2026-05-27 | PR #37 mergeado. Migración RandomForest → XGBoost con training incremental en chunks mensuales. R² del modelo en producción: gas 0.869 / pet 0.895 (validado end-to-end). Resuelve OOM estructural y habilita entrenar con histórico completo. |
+| ✅ Mergeado | #14 Validación de schema CSV | 2026-05-27 | Task `validate_dataset` entre `download_dataset` y `prepare_offline_store`. Valida columnas requeridas, campos críticos no vacíos, rango de años y mínimo de filas. Falla con mensaje claro antes de que datos corruptos lleguen al feature store. Decisión #16 en README. |
 **Pendientes consolidados en el [Backlog priorizado](#backlog-priorizado) más abajo** — incluye los issues del roadmap original (#9, #10, #11, #13, #14, #15, #16, #17, #18) y los detectados durante reviews de las clases 6, 7 y 8 (#26, #27, #28, #38, #39, #40-44, #46-48).
 
 **Notas sobre la evolución del scope:**
@@ -39,7 +40,7 @@ Criterio de los niveles:
 |---|---|---|
 | **P1** | [#46](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/46) Alerta de modelo stale | Detecta DAG fallando silenciosamente. Endpoint `/health/staleness` o tarea Airflow independiente. Origen: Clase 7, Caso 1 YarnIt. |
 | **P1** | [#47](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/47) Validación de outputs (NaN / rangos físicos) | Defensivo. Evita devolver predicciones absurdas (negativas, NaN) al consumidor. Origen: Clase 7, slide 62. |
-| **P1** | [#14](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/14) Validación de schema CSV con pandera | Detecta cambios upstream en el dataset MINEM antes de romper en una tarea posterior. Origen: roadmap original. |
+| ✅ **Cerrado** | [#14](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/14) Validación de schema CSV | Implementado en task `validate_dataset` (2026-05-27). Validación manual con pandas: columnas requeridas, campos críticos no vacíos, rango de años, mínimo de filas. Decisión #16 en README. |
 | **P1** | [#42](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/42) Health check + graceful degradation | Endpoints `/health/live` y `/health/ready` + fallback al modelo cacheado en disco. Origen: Clase 6, slides 36 y 52. |
 | **P1** | [#41](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/41) Autenticación API key | Hoy `/api/v1/*` están abiertos. Mínimo: `X-API-Key` validado contra `.env`. Origen: Clase 6, slide 52. |
 | **P2** | [#40](https://github.com/fedehofmann/oil_and_gas_mlops_pipeline/issues/40) Métricas de latencia P50/P90/P99 | Prerrequisito para definir SLA y para validar #27/#28. Origen: Clase 6, slides 7, 27, 52. |


### PR DESCRIPTION
… (cierra #14)

- Nueva task entre download_dataset y prepare_offline_store
- Valida columnas requeridas, campos críticos no vacíos, rango de años y mínimo de filas
- Falla con ValueError descriptivo antes de que datos corruptos lleguen al feature store
- No carga el CSV completo: usa nrows=1000 para schema y streaming para conteo de filas
- Agrega Decisión #16 en README
- Marca #14 como cerrado en el roadmap (tabla de estado + backlog priorizado)